### PR TITLE
feat: add `external link label` option and `venue` option to event info block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "1.0.53",
+    "version": "1.0.54",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.53
+ * @version     1.0.54
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -13,7 +13,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.2
  * Tested up to:            6.4
- * Version:                 1.0.53
+ * Version:                 1.0.54
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '1.0.53' );
+define( 'SE_VERSION', '1.0.54' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/src/blocks/event-info/block.json
+++ b/src/blocks/event-info/block.json
@@ -30,6 +30,9 @@
             "type": "boolean",
             "default": true
         },
+        "externalLinkLabel": {
+            "type": "string"
+        },
         "externalLink": {
             "type": "string"
         }

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -741,6 +741,7 @@ registerBlockType('simple-events/event-info', {
 							eventDates: meta?.se_event_dates,
 							eventTimezone: meta?.se_event_timezone,
 							externalLink: meta?.se_event_external_link,
+							externalLinkLabel: meta?.se_event_external_link_label,
 							addCalendarLinks: meta?.se_event_add_calendar_links,
 						}}
 					/>
@@ -794,19 +795,34 @@ registerBlockType('simple-events/event-info', {
 						type="url"
 					/>
 					{meta?.se_event_external_link && (
-						<CheckboxControl
-							label={__(
-								'Open external link from calendar',
-								'simple-events'
-							)}
-							checked={meta?.se_open_external_link ?? false}
-							onChange={(value) => {
-								setMeta({
-									...meta,
-									se_open_external_link: value,
-								});
-							}}
-						/>
+						<>
+							<TextControl
+								className="se-location-label"
+								label={__('External Link Label', 'simple-events')}
+								value={meta?.se_event_external_link_label}
+								onChange={(value) =>
+									setMeta({
+										...meta,
+										se_event_external_link_label: value,
+									})
+								}
+								type="text"
+							/>
+							<CheckboxControl
+								label={__(
+									'Open external link from calendar',
+									'simple-events'
+								)}
+								checked={meta?.se_open_external_link ?? false}
+								onChange={(value) => {
+									setMeta({
+										...meta,
+										se_open_external_link: value,
+									});
+								}}
+							/>
+						</>
+
 					)}
 
 					<Button

--- a/src/blocks/loop-event-info/block.json
+++ b/src/blocks/loop-event-info/block.json
@@ -18,7 +18,7 @@
 			"default": 0
 		},
 		"metaName": {
-			"enum": ["location", "dates", "date", "time"],
+			"enum": ["location", "venue", "dates", "date", "time"],
 			"type": "string",
 			"default": "dates"
 		},

--- a/src/blocks/loop-event-info/index.js
+++ b/src/blocks/loop-event-info/index.js
@@ -30,7 +30,7 @@ registerBlockType(metadata, {
 							label={__('Show what event info?', 'simple-events')}
 							value={metaName}
 							options={[
-								{ label: __( 'Dates & Time', 'simple-events' ), value: 'dates' },
+								{ label: __( 'Date & Time', 'simple-events' ), value: 'dates' },
 								{ label: __( 'Location', 'simple-events' ), value: 'location' },
 								{ label: __( 'Venue', 'simple-events' ), value: 'venue' },
 								{ label: __( 'Date Only', 'simple-events' ), value: 'date' },

--- a/src/blocks/loop-event-info/index.js
+++ b/src/blocks/loop-event-info/index.js
@@ -30,10 +30,11 @@ registerBlockType(metadata, {
 							label={__('Show what event info?', 'simple-events')}
 							value={metaName}
 							options={[
-								{ label: 'Date & Time', value: 'dates' },
-								{ label: 'Location', value: 'location' },
-								{ label: 'Date Only', value: 'date' },
-								{ label: 'Time Only', value: 'time' },
+								{ label: __( 'Dates & Time', 'simple-events' ), value: 'dates' },
+								{ label: __( 'Location', 'simple-events' ), value: 'location' },
+								{ label: __( 'Venue', 'simple-events' ), value: 'venue' },
+								{ label: __( 'Date Only', 'simple-events' ), value: 'date' },
+								{ label: __( 'Time Only', 'simple-events' ), value: 'time' },
 							]}
 							onChange={(value) =>
 								setAttributes({ metaName: value })

--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -274,7 +274,8 @@ class SE_Blocks {
 		$event_location = get_post_meta( $post_ID, 'se_event_location', true );
 		$event_venue    = get_post_meta( $post_ID, 'se_event_venue', true );
 
-		$event_link = get_post_meta( $post_ID, 'se_event_external_link', true );
+		$event_link       = get_post_meta( $post_ID, 'se_event_external_link', true );
+		$event_link_label = get_post_meta( $post_ID, 'se_event_external_link_label', true );
 
 		// Previewing?
 		if ( isset( $attributes['eventLocation'] ) ) {
@@ -288,6 +289,10 @@ class SE_Blocks {
 		// Previewing?
 		if ( isset( $attributes['externalLink'] ) ) {
 			$event_link = $attributes['externalLink'];
+		}
+
+		if ( isset( $attributes['externalLinkLabel'] ) ) {
+			$event_link_label = $attributes['externalLinkLabel'];
 		}
 
 		if ( ! empty( $dates_output ) ) {
@@ -308,8 +313,7 @@ class SE_Blocks {
 			}
 
 			if ( ! empty( $event_link ) ) {
-				$link_text = __( 'Tickets', 'simple-events' );
-				$cta       = apply_filters( 'se_event_external_link_text', $link_text, $event_link );
+				$cta = apply_filters( 'se_event_external_link_text', $event_link_label, $event_link );
 
 				$output .= '<p><a class="wp-block-se-event-link" href="' . esc_url( $event_link ) . '" target="_blank" rel="nofollow">' . $cta . '</a></p>';
 			}

--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -746,6 +746,9 @@ class SE_Blocks {
 				case 'location':
 					$output = se_event_get_location( $post_ID );
 					break;
+				case 'venue':
+					$output = se_event_get_venue( $post_ID );
+					break;
 				case 'dates':
 					$output = se_event_get_future_dates( $post_ID );
 					break;
@@ -764,6 +767,9 @@ class SE_Blocks {
 			switch ( $attributes['metaName'] ) {
 				case 'location':
 					$output = esc_html__( 'Example Location Name', 'simple-events' );
+					break;
+				case 'venue':
+					$output = esc_html__( 'Example Venue Name', 'simple-events' );
 					break;
 				case 'dates':
 					$output = esc_html__( 'June 20, 2023 9:00 am - 10:00 am', 'simple-events' );

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -318,6 +318,18 @@ class SE_Event_Post_Type {
 
 		register_meta(
 			'post',
+			'se_event_external_link_label',
+			array(
+				'show_in_rest'   => true,
+				'single'         => true,
+				'type'           => 'string',
+				'object_subtype' => self::$post_type,
+				'default'        => esc_html__( 'Tickets', 'simple-events' ),
+			)
+		);
+
+		register_meta(
+			'post',
 			'se_open_external_link',
 			array(
 				'show_in_rest'   => true,

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -375,6 +375,23 @@ function se_event_get_location( $event_id ) {
 }
 
 /**
+ * Get event venue.
+ *
+ * @param integer $event_id Event id.
+ *
+ * @return mixed
+ */
+function se_event_get_venue( $event_id ) {
+	$event_venue = get_post_meta( $event_id, 'se_event_venue', true );
+
+	if ( ! empty( $event_venue ) ) {
+		return $event_venue;
+	}
+
+	return false;
+}
+
+/**
  * Whether or not an event is past its date.
  *
  * @param integer $event_id Event id.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* See https://github.com/a8cteam51/marcosvarelamusic/issues/159

1. Adds `External Link Label` option to Events Info block. 

* Only visible if the `External Link` option is set.
* Existing posts that don't have the meta saved will fallback to the default `Tickets` text.

<img width="450" alt="image" src="https://github.com/user-attachments/assets/8cc951ba-851f-41b6-9a23-bdd22ce3cf50" />

2. Adds `Venue` option to Event Info block:

<img width="278" alt="image" src="https://github.com/user-attachments/assets/9fc9ddf0-3bef-46b8-8070-251febddcd39" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom label for external event links in the event info block. Users can now enter a custom call-to-action text for external links, replacing the default label.
  - Added venue display option to loop event info block, allowing venue details to be shown alongside other event information.
- **Chores**
  - Updated version numbers to 1.0.54 across the plugin and package files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->