### PR TITLE
Fix/ensure dates in past have start end meta set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "1.0.51",
+    "version": "1.0.54",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wpcomsp-simple-events",
-            "version": "1.0.51",
+            "version": "1.0.54",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "ajv": "^8.17.1"
@@ -4388,23 +4388,6 @@
                 "url": "https://opencollective.com/pkgr"
             }
         },
-        "node_modules/@playwright/test": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
-            "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "playwright": "1.52.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.5.16",
             "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.16.tgz",
@@ -5727,22 +5710,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/@types/wordpress__block-editor/node_modules/react": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-            "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/@types/wordpress__block-editor/node_modules/react-autosize-textarea": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
@@ -5757,35 +5724,6 @@
             "peerDependencies": {
                 "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
                 "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
-            }
-        },
-        "node_modules/@types/wordpress__block-editor/node_modules/react-dom": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-            "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.19.1"
-            },
-            "peerDependencies": {
-                "react": "^16.14.0"
-            }
-        },
-        "node_modules/@types/wordpress__block-editor/node_modules/scheduler": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-            "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
             }
         },
         "node_modules/@types/wordpress__block-library": {
@@ -7773,23 +7711,6 @@
                 "react-with-styles": "^3.0.0"
             }
         },
-        "node_modules/@woocommerce/components/node_modules/@wordpress/components/node_modules/react-with-styles/node_modules/react-dom": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-            "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.19.1"
-            },
-            "peerDependencies": {
-                "react": "^16.14.0"
-            }
-        },
         "node_modules/@woocommerce/components/node_modules/@wordpress/components/node_modules/react-with-styles/node_modules/react-with-direction": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/react-with-direction/-/react-with-direction-1.4.0.tgz",
@@ -7894,18 +7815,6 @@
             },
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0"
-            }
-        },
-        "node_modules/@woocommerce/components/node_modules/@wordpress/components/node_modules/scheduler": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-            "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
             }
         },
         "node_modules/@woocommerce/components/node_modules/@wordpress/compose": {
@@ -12087,7 +11996,8 @@
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
             "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/postcss/"
                 },
@@ -12544,7 +12454,8 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -12721,7 +12632,8 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
             "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/browserslist"
                 },
@@ -12763,7 +12675,8 @@
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -12952,7 +12865,8 @@
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
             "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/browserslist"
                 },
@@ -13147,10 +13061,12 @@
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
             "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
             "dev": true,
-            "funding": [{
-                "type": "github",
-                "url": "https://github.com/sponsors/sibiraj-s"
-            }],
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -14769,10 +14685,12 @@
             "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
             "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "dev": true,
-            "funding": [{
-                "type": "github",
-                "url": "https://github.com/sponsors/fb55"
-            }],
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
             "license": "BSD-2-Clause"
         },
         "node_modules/domexception": {
@@ -16616,7 +16534,8 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
             "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/fastify"
                 },
@@ -16912,10 +16831,12 @@
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
             "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
             "dev": true,
-            "funding": [{
-                "type": "individual",
-                "url": "https://github.com/sponsors/RubenVerborgh"
-            }],
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
             "license": "MIT",
             "engines": {
                 "node": ">=4.0"
@@ -17823,7 +17744,8 @@
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
             "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/mdevils"
                 },
@@ -18040,7 +17962,8 @@
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
             "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -21354,10 +21277,12 @@
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
             "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
-            "funding": [{
-                "type": "github",
-                "url": "https://github.com/sponsors/ai"
-            }],
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
             "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -22553,56 +22478,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/playwright": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-            "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "dependencies": {
-                "playwright-core": "1.52.0"
-            },
-            "bin": {
-                "playwright": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
-            }
-        },
-        "node_modules/playwright-core": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-            "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "playwright-core": "cli.js"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/playwright/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "peer": true,
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/plur": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -22647,7 +22522,8 @@
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
             "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/postcss/"
                 },
@@ -23269,7 +23145,8 @@
             "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
             "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/postcss/"
                 },
@@ -23660,7 +23537,8 @@
             "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
             "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "individual",
                     "url": "https://github.com/sponsors/dubzzz"
                 },
@@ -23699,7 +23577,8 @@
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -24138,23 +24017,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/react-with-styles/node_modules/react-dom": {
-            "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-            "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2",
-                "scheduler": "^0.19.1"
-            },
-            "peerDependencies": {
-                "react": "^16.14.0"
-            }
-        },
         "node_modules/react-with-styles/node_modules/react-is": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -24181,18 +24043,6 @@
             "peerDependencies": {
                 "react": "^0.14 || ^15 || ^16",
                 "react-dom": "^0.14 || ^15 || ^16"
-            }
-        },
-        "node_modules/react-with-styles/node_modules/scheduler": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-            "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1"
             }
         },
         "node_modules/read-cache": {
@@ -24859,7 +24709,8 @@
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
             "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -24919,7 +24770,8 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "github",
                     "url": "https://github.com/sponsors/feross"
                 },
@@ -27395,21 +27247,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "node_modules/uc.micro": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -27536,7 +27373,8 @@
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
             "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "dev": true,
-            "funding": [{
+            "funding": [
+                {
                     "type": "opencollective",
                     "url": "https://opencollective.com/browserslist"
                 },

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -89,10 +89,6 @@ const getStartAndEndDate = (dates) => {
 			moment.unix(date.datetime_end).utcOffset(OFFSET)
 		);
 
-		console.log('Processing only past dates.');
-		console.log({'dates' : dates, 'allStartDates': allStartDates, 'allEndDates': allEndDates});
-
-
 		// Return the latest start date and earliest end date.
 		return {
 			datetime_start: moment.max(allStartDates).unix().toString(),

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -89,6 +89,10 @@ const getStartAndEndDate = (dates) => {
 			moment.unix(date.datetime_end).utcOffset(OFFSET)
 		);
 
+		console.log('Processing only past dates.');
+		console.log({'dates' : dates, 'allStartDates': allStartDates, 'allEndDates': allEndDates});
+
+
 		// Return the latest start date and earliest end date.
 		return {
 			datetime_start: moment.max(allStartDates).unix().toString(),

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -136,7 +136,6 @@ const getStartAndEndDate = (dates) => {
 
 	// If we have no startDate or endDate, just get the first from dates.
 	if (!startDate) {
-
 		startDate = moment.unix(head(filteredDates).datetime_start).utcOffset(OFFSET);
 	}
 	if (!endDate) {
@@ -265,10 +264,7 @@ registerBlockType('simple-events/event-info', {
 			});
 		};
 
-
-
 		const maybeUpdateEventDateTime = (oldDate, newDate) => {
-
 			if (!isEqual(oldDate, newDate)) {
 				const updatedDates = sortBy(
 					meta?.se_event_dates.map((item) =>

--- a/src/blocks/event-info/index.js
+++ b/src/blocks/event-info/index.js
@@ -79,13 +79,25 @@ const getStartAndEndDate = (dates) => {
 		return endDate.isAfter(now);
 	});
 
+	// If we have no filtered dates, but we had dates, before.
+	if (filteredDates.length === 0 && dates.length > 0) {
+		// Extract all start dates with the offset.
+		const allStartDates = dates.map((date) =>
+			moment.unix(date.datetime_start).utcOffset(OFFSET)
+		);
+		const allEndDates = dates.map((date) =>
+			moment.unix(date.datetime_end).utcOffset(OFFSET)
+		);
+
+		// Return the latest start date and earliest end date.
+		return {
+			datetime_start: moment.max(allStartDates).unix().toString(),
+			datetime_end: moment.max(allEndDates).unix().toString(),
+		}
+	}
+
 	let startDate = null;
 	let endDate = null;
-
-	// Do not trust the order of the dates.
-	if (filteredDates.length === 0) {
-		return { datetime_start: null, datetime_end: null };
-	}
 
 	// Loop over the dates and set the start date as the earliest and the end as the latest.
 	filteredDates.forEach((date) => {
@@ -124,11 +136,13 @@ const getStartAndEndDate = (dates) => {
 
 	// If we have no startDate or endDate, just get the first from dates.
 	if (!startDate) {
+
 		startDate = moment.unix(head(filteredDates).datetime_start).utcOffset(OFFSET);
 	}
 	if (!endDate) {
 		endDate = moment.unix(last(filteredDates).datetime_end).utcOffset(OFFSET);
 	}
+
 	return {
 		datetime_start: startDate.unix().toString(),
 		datetime_end: endDate.unix().toString(),
@@ -251,7 +265,10 @@ registerBlockType('simple-events/event-info', {
 			});
 		};
 
+
+
 		const maybeUpdateEventDateTime = (oldDate, newDate) => {
+
 			if (!isEqual(oldDate, newDate)) {
 				const updatedDates = sortBy(
 					meta?.se_event_dates.map((item) =>

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -159,7 +159,7 @@ class SE_Event_Post_Type {
 	 *
 	 * @return boolean
 	 */
-	public static function is_protected_meta( bool $is_protected, string $meta_key, string $meta_type = 'string' ) {
+	public static function is_protected_meta( bool $is_protected, string $meta_key, string $meta_type = 'string' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$protected_keys = array( 'se_event_date_end', 'se_event_date_start' );
 
 		if ( in_array( $meta_key, $protected_keys, true ) ) {
@@ -233,7 +233,7 @@ class SE_Event_Post_Type {
 				'object_subtype' => self::$post_type,
 				'auth_callback'  => function () {
 					return current_user_can( 'edit_posts' );
-				}
+				},
 			)
 		);
 

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -41,6 +41,7 @@ class SE_Event_Post_Type {
 		add_filter( 'get_the_archive_title', array( __CLASS__, 'the_archive_title' ) );
 		register_activation_hook( __FILE__, array( __CLASS__, 'flush_rewrite_rules' ) );
 		add_action( 'save_post', array( __CLASS__, 'delete_event_dates_if_no_event_info_block' ) );
+		add_filter( 'is_protected_meta', array( __CLASS__, 'is_protected_meta' ), 10, 3 );
 	}
 
 	/**
@@ -148,6 +149,26 @@ class SE_Event_Post_Type {
 	}
 
 	/**
+	 * Defines protected meta keys for the event post type.
+	 *
+	 * This method registers meta keys that are used to store event-related data.
+	 *
+	 * @param boolean $is_protected Whether the meta keys should be protected.
+	 * @param string  $meta_key     The meta key to register.
+	 * @param string  $meta_type    The type of the meta key.
+	 *
+	 * @return boolean
+	 */
+	public static function is_protected_meta( bool $is_protected, string $meta_key, string $meta_type = 'string' ) {
+		$protected_keys = array( 'se_event_date_end', 'se_event_date_start' );
+
+		if ( in_array( $meta_key, $protected_keys, true ) ) {
+			return true;
+		}
+		return $is_protected;
+	}
+
+	/**
 	 * Register meta keys.
 	 *
 	 * @return void
@@ -210,6 +231,9 @@ class SE_Event_Post_Type {
 				'single'         => true,
 				'type'           => 'string',
 				'object_subtype' => self::$post_type,
+				'auth_callback'  => function () {
+					return current_user_can( 'edit_posts' );
+				}
 			)
 		);
 
@@ -221,6 +245,9 @@ class SE_Event_Post_Type {
 				'single'         => true,
 				'type'           => 'string',
 				'object_subtype' => self::$post_type,
+				'auth_callback'  => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			)
 		);
 

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -509,15 +509,13 @@ function se_event_update_event_query_dates( $event_id ) {
 	// If we have no start date, but we have dates, set to the earliest.
 	if ( null === $start_date && ! empty( $event_dates ) ) {
 		$all_start_dates = wp_list_pluck( $event_dates, 'datetime_start' );
-		rsort( $all_start_dates );
-		$start_date = $all_start_dates[0];
+		$start_date      = max( $all_start_dates );
 	}
 	// If we have no end date, but we have dates, set to the latest.
 	if ( null === $end_date && ! empty( $event_dates ) ) {
 		// Get the latest end date.
 		$all_end_dates = wp_list_pluck( $event_dates, 'datetime_end' );
-		rsort( $all_end_dates );
-		$end_date = $all_end_dates[0];
+		$end_date      = max( $all_end_dates ); // latest end
 	}
 
 	// If we have a start date, set it.

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -509,13 +509,17 @@ function se_event_update_event_query_dates( $event_id ) {
 	// If we have no start date, but we have dates, set to the earliest.
 	if ( null === $start_date && ! empty( $event_dates ) ) {
 		$all_start_dates = wp_list_pluck( $event_dates, 'datetime_start' );
-		sort( $all_start_dates );
+		rsort( $all_start_dates );
 		// get the latest start d
-		$start_date = $all_start_dates[ count( $all_start_dates ) - 1 ];
+		$start_date = $all_start_dates[0];
 	}
 	// If we have no end date, but we have dates, set to the latest.
 	if ( null === $end_date && ! empty( $event_dates ) ) {
-		$end_date = $event_dates[ count( $event_dates ) - 1 ]['datetime_end'];
+		// Get the latest end date.
+		$all_end_dates = wp_list_pluck( $event_dates, 'datetime_end' );
+		rsort( $all_end_dates );
+
+		$end_date = $all_end_dates[0];
 	}
 
 	// If we have a start date, set it.

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -510,7 +510,6 @@ function se_event_update_event_query_dates( $event_id ) {
 	if ( null === $start_date && ! empty( $event_dates ) ) {
 		$all_start_dates = wp_list_pluck( $event_dates, 'datetime_start' );
 		rsort( $all_start_dates );
-		// get the latest start d
 		$start_date = $all_start_dates[0];
 	}
 	// If we have no end date, but we have dates, set to the latest.
@@ -518,7 +517,6 @@ function se_event_update_event_query_dates( $event_id ) {
 		// Get the latest end date.
 		$all_end_dates = wp_list_pluck( $event_dates, 'datetime_end' );
 		rsort( $all_end_dates );
-
 		$end_date = $all_end_dates[0];
 	}
 

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -506,6 +506,18 @@ function se_event_update_event_query_dates( $event_id ) {
 		}
 	}
 
+	// If we have no start date, but we have dates, set to the earliest.
+	if ( null === $start_date && ! empty( $event_dates ) ) {
+		$all_start_dates = wp_list_pluck( $event_dates, 'datetime_start' );
+		sort( $all_start_dates );
+		// get the latest start d
+		$start_date = $all_start_dates[ count( $all_start_dates ) - 1 ];
+	}
+	// If we have no end date, but we have dates, set to the latest.
+	if ( null === $end_date && ! empty( $event_dates ) ) {
+		$end_date = $event_dates[ count( $event_dates ) - 1 ]['datetime_end'];
+	}
+
 	// If we have a start date, set it.
 	if ( null !== $start_date ) {
 		update_post_meta( $event_id, 'se_event_date_start', esc_attr( $start_date ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that if the only date/dates are in the past, we still use those dates (otherwise none) and use the last start and end date. This is also reflected in the cron that runs to update old events.
* Ensure that the start and end dates are protected so they dont appear in the custom fields meta box and we have the classic Gutenberg meta race condition!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of event dates to ensure start and end dates are always set, even if all event dates are in the past.
- **New Features**
	- Enhanced protection for certain event date fields, restricting access to users with appropriate permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->