### PR TITLE
bumped all version to 1.0.55

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "1.0.54",
+    "version": "1.0.55",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     1.0.54
+ * @version     1.0.55
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -13,7 +13,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.2
  * Tested up to:            6.4
- * Version:                 1.0.54
+ * Version:                 1.0.55
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '1.0.54' );
+define( 'SE_VERSION', '1.0.55' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin version from `1.0.54` to `1.0.55` across multiple files to reflect the latest release.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the `version` field to `1.0.55`.
* [`plugin.php`](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L6-R6): Updated the version in the plugin metadata, including the `@version` tag, the `Version` field, and the `SE_VERSION` constant definition. [[1]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L6-R6) [[2]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L16-R16) [[3]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L34-R34)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the plugin version to 1.0.55 across all relevant files and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->