### PR TITLE
Bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     2.0.1
+ * @version     2.0.2
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -13,7 +13,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.2
  * Tested up to:            6.4
- * Version:                 2.0.1
+ * Version:                 2.0.2
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '2.0.1' );
+define( 'SE_VERSION', '2.0.2' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*
This pull request updates the version of the `wpcomsp-simple-events` plugin from `2.0.1` to `2.0.2` across multiple files to ensure consistency and reflect the new release.

### Version updates:

* Updated the `version` field in `package.json` to `2.0.2`. (`[package.jsonL3-R3](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)`)
* Updated the `@version` tag in the plugin header comment in `plugin.php` to `2.0.2`. (`[plugin.phpL6-R6](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L6-R6)`)
* Updated the `Version` field in the plugin metadata in `plugin.php` to `2.0.2`. (`[plugin.phpL16-R16](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L16-R16)`)
* Updated the `SE_VERSION` constant in `plugin.php` to `2.0.2`. (`[plugin.phpL34-R34](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L34-R34)`)
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version number to 2.0.2 in plugin metadata and related files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->