### PR TITLE
Fix/archives reverting to dates

### DIFF
--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -281,6 +281,7 @@ class SE_Blocks {
 		}
 
 		$dates_output = '';
+		$date_heading = '';
 
 		if ( ! empty( $event_dates ) ) {
 			$has_header_date = false;

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -659,7 +659,7 @@ class SE_Event_Post_Type {
 	public static function handle_expired_events() {
 		global $wp_query;
 
-		if ( $wp_query->is_singular( self::$post_type ) ) {
+		if ( $wp_query->is_singular( self::$post_type ) || $wp_query->is_singular( self::$event_date_post_type ) ) {
 			$options = get_option( 'se_options' );
 
 			// Values for which passed events should be shown on Single View.

--- a/src/classes/class-se-template-loader.php
+++ b/src/classes/class-se-template-loader.php
@@ -30,14 +30,31 @@ class SE_Template_Loader {
 	 * @return string
 	 */
 	public static function template_include( $template ) {
+		// Check if we are looking for a single event or event date template.
+		if ( is_single() && get_post_type() === SE_Event_Post_Type::$post_type ) {
+			// Attempt to look for the single event template in themes etc.
+			$theme_templates = array(
+				'single-se-event.php',
+			);
+			// Determine if any of these templates is available in the theme.
+			$single_event_template = get_query_template( 'singular', $theme_templates );
+			if ( ! $single_event_template ) {
+				// If not use our custom template.
+				$plugins_own = self::locate_template( array( 'single.php' ) );
+				if ( $plugins_own ) {
+					return $plugins_own;
+				}
+			}
+		}
+
 		// Return early if this view is not an event view.
-		if ( ! is_singular( 'se-event' ) && ! is_post_type_archive( 'se-event' ) ) {
+		if ( ! is_singular( 'se-event-date' ) && ! is_post_type_archive( 'se-event-date' ) ) {
 			return $template;
 		}
 
 		// Determine if standard single se-event templates are available in the theme
 		// before replacing with the custom template in this plugin.
-		if ( is_singular( 'se-event' ) ) {
+		if ( is_singular( 'se-event-date' ) ) {
 			$event = get_post();
 
 			$theme_templates = array(
@@ -62,14 +79,13 @@ class SE_Template_Loader {
 
 		// Determine if standard se-event archive templates are available in the theme
 		// before replacing with the custom template in this plugin.
-		if ( is_archive( 'se-event' ) ) {
+		if ( is_archive( 'se-event-date' ) ) {
 			$theme_templates = array(
 				'archive-se-event.php',
 			);
 
 			// Determine if any of these templates is available in the theme.
 			$archive_event_template = get_query_template( 'archive', $theme_templates );
-
 			if ( $archive_event_template ) {
 				return $archive_event_template;
 			}

--- a/src/classes/class-se-template-loader.php
+++ b/src/classes/class-se-template-loader.php
@@ -42,7 +42,11 @@ class SE_Template_Loader {
 				// If not use our custom template.
 				$plugins_own = self::locate_template( array( 'single.php' ) );
 				if ( $plugins_own ) {
-					return $plugins_own;
+					// Allow filters to override the template.
+					$plugins_own = apply_filters( 'se_single_event_template', $plugins_own );
+					if ( $plugins_own ) {
+						return $plugins_own;
+					}
 				}
 			}
 		}
@@ -97,6 +101,8 @@ class SE_Template_Loader {
 		$fallback_template = self::locate_template( array( $fallback_template ) );
 
 		if ( '' !== $fallback_template ) {
+			// Allow filters to override the template.
+			$fallback_template = apply_filters( 'se_event_archive_template_legacy', $fallback_template );
 			return $fallback_template;
 		}
 

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -567,3 +567,25 @@ if ( ! function_exists( 'se_template_event_content' ) ) {
 	}
 }
 
+
+if ( ! function_exists( 'se_fix_se_events_fse_archive_template' ) ) {
+	/**
+	 * Fix the template hierarchy for the SE Events FSE archive.
+	 *
+	 * @param array $templates The template hierarchy.
+	 *
+	 * @return array The modified template hierarchy.
+	 */
+	function se_fix_se_events_fse_archive_template( $templates ) {
+		if ( 'se-event-date' === get_query_var( 'post_type' ) ) {
+			// Create proper hierarchy: archive-se-events.html, then archive.html
+			$custom_hierarchy = array(
+				'archive-se-event.html',
+				'archive.html',
+			);
+
+			return $custom_hierarchy;
+		}
+		return $templates;
+	}
+}

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -601,8 +601,8 @@ if ( ! function_exists( 'se_modify_event_date_archive_body_class' ) ) {
 	 */
 	function se_modify_event_date_archive_body_class( $classes ) {
 		$classes = array_map(
-			function ( $class ) {
-				return 'post-type-archive-se-event-date' === $class ? 'post-type-archive-se-event' : $class;
+			function ( $body_class ) {
+				return 'post-type-archive-se-event-date' === $body_class ? 'post-type-archive-se-event' : $class;
 			},
 			$classes
 		);
@@ -627,14 +627,14 @@ if ( ! function_exists( 'se_modify_event_date_archive_template_title' ) ) {
 
 			// If this is a post_typw archive, use the post type archive title.
 			if ( is_post_type_archive() ) {
-				$title  = apply_filters( 'post_type_archive_title', $post_type_obj->labels->name, 'se-event' );
-				$prefix = _x( 'Archives:', 'post type archive title prefix' );
+				$title  = apply_filters( 'post_type_archive_title', $post_type_obj->labels->name, 'se-event' ); // phpcs:ignore
+				$prefix = _x( 'Archives:', 'post type archive title prefix' ); // phpcs:ignore
 			} elseif ( is_tax() && $post_type_obj ) {
 				$tax    = get_taxonomy( $post_type_obj->taxonomy );
 				$title  = single_term_title( '', false );
 				$prefix = sprintf(
 				/* translators: %s: Taxonomy singular name. */
-					_x( '%s:', 'taxonomy term archive title prefix' ),
+					_x( '%s:', 'taxonomy term archive title prefix' ), // phpcs:ignore
 					$tax->labels->singular_name
 				);
 			} else {
@@ -648,11 +648,11 @@ if ( ! function_exists( 'se_modify_event_date_archive_template_title' ) ) {
 			 *
 			 * @param string $prefix Archive title prefix.
 			 */
-			$prefix = apply_filters( 'get_the_archive_title_prefix', $prefix );
+			$prefix = apply_filters( 'get_the_archive_title_prefix', $prefix ); // phpcs:ignore
 			if ( $prefix ) {
 				$title = sprintf(
 					/* translators: 1: Title prefix. 2: Title. */
-					_x( '%1$s %2$s', 'archive title' ),
+					_x( '%1$s %2$s', 'archive title' ), // phpcs:ignore
 					$prefix,
 					'<span>' . $title . '</span>'
 				);

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -589,3 +589,119 @@ if ( ! function_exists( 'se_fix_se_events_fse_archive_template' ) ) {
 		return $templates;
 	}
 }
+
+// Filter to modify the body class for the event date archive.
+if ( ! function_exists( 'se_modify_event_date_archive_body_class' ) ) {
+	/**
+	 * Modify the body class for the event date archive.
+	 *
+	 * @param array $classes The existing body classes.
+	 *
+	 * @return array The modified body classes.
+	 */
+	function se_modify_event_date_archive_body_class( $classes ) {
+		$classes = array_map(
+			function ( $class ) {
+				return 'post-type-archive-se-event-date' === $class ? 'post-type-archive-se-event' : $class;
+			},
+			$classes
+		);
+		return $classes;
+	}
+}
+
+// Modify the archive page title.
+if ( ! function_exists( 'se_modify_event_date_archive_template_title' ) ) {
+	/**
+	 * Modify the archive page title for the event date archive.
+	 *
+	 * @param string $title The existing archive title.
+	 *
+	 * @return string The modified archive title.
+	 */
+	function se_modify_event_date_archive_template_title( $title ) {
+		if ( is_post_type_archive( 'se-event-date' ) ) {
+			$original_title = $title;
+			// Get the se-event post type object to use its archive title
+			$post_type_obj = get_post_type_object( 'se-event' );
+
+			// If this is a post_typw archive, use the post type archive title.
+			if ( is_post_type_archive() ) {
+				$title  = apply_filters( 'post_type_archive_title', $post_type_obj->labels->name, 'se-event' );
+				$prefix = _x( 'Archives:', 'post type archive title prefix' );
+			} elseif ( is_tax() && $post_type_obj ) {
+				$tax    = get_taxonomy( $post_type_obj->taxonomy );
+				$title  = single_term_title( '', false );
+				$prefix = sprintf(
+				/* translators: %s: Taxonomy singular name. */
+					_x( '%s:', 'taxonomy term archive title prefix' ),
+					$tax->labels->singular_name
+				);
+			} else {
+				$prefix = '';
+			}
+
+			/**
+			 * Filters the archive title prefix.
+			 *
+			 * @since 5.5.0
+			 *
+			 * @param string $prefix Archive title prefix.
+			 */
+			$prefix = apply_filters( 'get_the_archive_title_prefix', $prefix );
+			if ( $prefix ) {
+				$title = sprintf(
+					/* translators: 1: Title prefix. 2: Title. */
+					_x( '%1$s %2$s', 'archive title' ),
+					$prefix,
+					'<span>' . $title . '</span>'
+				);
+			}
+		}
+		return $title;
+	}
+}
+
+
+
+// Modify the page HTML title for the event date archive.
+if ( ! function_exists( 'se_modify_event_date_archive_page_title' ) ) {
+	/**
+	 * Modify the page HTML title for the event date archive.
+	 *
+	 * @param string $title The existing page title.
+	 *
+	 * @return string The modified page title.
+	 */
+	function se_modify_event_date_archive_page_title( $title ) {
+		if ( is_post_type_archive( 'se-event-date' ) ) {
+			$event_post_type = get_post_type_object( 'se-event' );
+			$title           = $event_post_type->labels->name;
+		} elseif ( is_tax() ) {
+			$taxonomy = get_queried_object();
+			if ( $taxonomy ) {
+				$title = $taxonomy->name;
+			}
+		}
+		return $title;
+	}
+}
+/**
+ * Ensure that legacy themes will call the se-event archive template.
+ *
+ * @since 2.0.0
+ *
+ * @param string $template The template file to use.
+ *
+ * @return string The modified template file.
+ */
+function se_event_archive_template( $template ) {
+	if ( is_post_type_archive( 'se-event-date' ) ) {
+		// If the template is not set, use the default archive template.
+		$date_archive_template = locate_template( 'archive-se-event.php' );
+		if ( $date_archive_template ) {
+			return $date_archive_template;
+		}
+	}
+	return $template;
+}

--- a/src/template-hooks.php
+++ b/src/template-hooks.php
@@ -35,3 +35,5 @@ add_action( 'se_single_content', 'the_content', 20 );
 add_action( 'se_single_content', 'se_template_calendar_links', 30 );
 // Show the next and previous links either above or below content (based on settings).
 add_action( 'se_single_content', 'se_template_event_next_previous', se_event_show_links_above_content() ? 40 : 15 );
+
+add_filter( 'archive_template_hierarchy', 'se_fix_se_events_fse_archive_template' );

--- a/src/template-hooks.php
+++ b/src/template-hooks.php
@@ -41,4 +41,3 @@ add_filter( 'archive_template_hierarchy', 'se_fix_se_events_fse_archive_template
 add_filter( 'pre_get_document_title', 'se_modify_event_date_archive_page_title' );
 add_filter( 'body_class', 'se_modify_event_date_archive_body_class' );
 add_filter( 'get_the_archive_title', 'se_modify_event_date_archive_template_title', 20, 1 );
-// add_filter( 'template_include', 'se_event_archive_template', 99 );

--- a/src/template-hooks.php
+++ b/src/template-hooks.php
@@ -36,4 +36,9 @@ add_action( 'se_single_content', 'se_template_calendar_links', 30 );
 // Show the next and previous links either above or below content (based on settings).
 add_action( 'se_single_content', 'se_template_event_next_previous', se_event_show_links_above_content() ? 40 : 15 );
 
+// V2 Fixes
 add_filter( 'archive_template_hierarchy', 'se_fix_se_events_fse_archive_template' );
+add_filter( 'pre_get_document_title', 'se_modify_event_date_archive_page_title' );
+add_filter( 'body_class', 'se_modify_event_date_archive_body_class' );
+add_filter( 'get_the_archive_title', 'se_modify_event_date_archive_template_title', 20, 1 );
+// add_filter( 'template_include', 'se_event_archive_template', 99 );

--- a/src/templates/content-single.php
+++ b/src/templates/content-single.php
@@ -9,12 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-
-<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<?php
 		/**
 		 * Hook: se_archive_content.
 		 */
 		do_action( 'se_single_content' );
 	?>
-</div>
+</article>

--- a/src/templates/content-single.php
+++ b/src/templates/content-single.php
@@ -9,11 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+<div id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<?php
 		/**
 		 * Hook: se_archive_content.
 		 */
 		do_action( 'se_single_content' );
 	?>
-</article>
+</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request introduces significant updates to the handling of event and event date post types, including template hierarchy fixes, archive page modifications, and adjustments to the rendering of single post content. The changes aim to improve compatibility with themes and enhance the flexibility of the plugin's template system.

### Template and Archive Handling Updates:
* [`src/classes/class-se-template-loader.php`](diffhunk://#diff-b3317441c4bc38531ad11ef5d23df548fde7e51f4634afcd0bb43cc520fddd57R33-R61): Added logic to handle custom templates for single and archive views of `se-event-date` post types, ensuring fallback templates and filters are applied correctly. [[1]](diffhunk://#diff-b3317441c4bc38531ad11ef5d23df548fde7e51f4634afcd0bb43cc520fddd57R33-R61) [[2]](diffhunk://#diff-b3317441c4bc38531ad11ef5d23df548fde7e51f4634afcd0bb43cc520fddd57L65-L72) [[3]](diffhunk://#diff-b3317441c4bc38531ad11ef5d23df548fde7e51f4634afcd0bb43cc520fddd57R104-R105)
* [`src/template-functions.php`](diffhunk://#diff-8ae56373366fd251055575924be04f99ad188082dede004fccf3765cf4044568R570-R707): Introduced functions to fix template hierarchy, modify body classes, and adjust archive and page titles for `se-event-date` archives.
* [`src/template-hooks.php`](diffhunk://#diff-293bd5d143140f9d407afff4a4971e8969c23be109b5dbfb3580644c049a21eaR38-R43): Added filters to integrate new template hierarchy fixes and title modifications into the plugin's hooks system.

### Single Post Content Rendering:
* [`src/templates/content-single.php`](diffhunk://#diff-6acc2de4a2ac1b5d99c1d033b24fdf665d4fdd72942e0c09c591bf77765fc0c2L12-R19): Updated the markup structure from `<div>` to `<article>` for better semantic HTML and compatibility with modern themes.

### Event Post Type Adjustments:
* [`src/classes/class-se-event-post-type.php`](diffhunk://#diff-1412c5700fff8340e2b4c8451a38920a841fbd8b98e970218910ed88a4fdcfd7L662-R662): Expanded conditional logic to include `se-event-date` post type in handling expired events.

### Miscellaneous Enhancements:
* [`src/classes/class-se-blocks.php`](diffhunk://#diff-106287f61ed160ba9908e5f59c68e4e93dd2ec9e2859d06feda411783b6949c9R284): Added a new variable `$date_heading` for potential future use in rendering event information.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved template handling for "se-event-date" archives, ensuring consistent template selection and fallback across different themes.
  * Enhanced archive page titles and body classes for "se-event-date" archives to better match "se-event" styling and behavior.

* **Bug Fixes**
  * Extended expired event handling to cover both "se-event" and "se-event-date" post types.

* **Style**
  * Minor whitespace cleanup in the single event content template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->