### PR TITLE
Fix/event ticketing block

### DIFF
--- a/src/blocks/event-tickets/index.js
+++ b/src/blocks/event-tickets/index.js
@@ -147,10 +147,10 @@ const TicketSelection = withState( {
 		setAttributes( { selected: ids } );
 	};
 
-	const getSelectedProducts = ( items = products ) => {
-		return selected.map( ( id ) =>
-			items.find( ( item ) => item.id === id )
-		);
+	const getSelectedProducts = (items = products) => {
+		return selected
+			.map((id) => items.find((item) => item.id === id))
+			.filter(Boolean); // This removes undefined items
 	};
 
 	const searchList = (

--- a/src/blocks/event-tickets/ticket-data-control/index.js
+++ b/src/blocks/event-tickets/ticket-data-control/index.js
@@ -6,7 +6,7 @@ import DraggableItem from '../draggable';
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from "@wordpress/api-fetch";
 import {
 	Button,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Adds a missing `sprintf` import.
- Removes undefined products while the block is loading.

#### Testing instructions

1. Install WooCommerce Box Office
2. Create a Woo Ticket Product
3. Create an event and add an event ticket block 
4. Select the event, save, and refresh
5. The block should normally render




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product selection to ensure only valid products are included when selecting event tickets.

* **Chores**
  * Updated internal imports for translation functions without affecting user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->