### PR TITLE
Feature/ghf35 resolve issue with non published events in pagination

### DIFF
--- a/src/classes/class-se-template-loader.php
+++ b/src/classes/class-se-template-loader.php
@@ -71,6 +71,9 @@ class SE_Template_Loader {
 			return $template;
 		}
 
+		// Define a fallback template.
+		$fallback_template = '';
+
 		// Determine if standard single se-event templates are available in the theme
 		// before replacing with the custom template in this plugin.
 		if ( is_singular( 'se-event-date' ) ) {

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -434,7 +434,7 @@ function se_event_get_next_event( int $event_id, ?int $event_date_id = null ): ?
 	);
 
 	// Ensure any events that are not published are not included in the query.
-	$args['post__not_in'] = se_get_dates_from_non_published_events();
+	$args['post__not_in'] = se_get_date_ids_for_non_published_events();
 
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
@@ -503,7 +503,7 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 	);
 
 	// Ensure any events that are not published are not included in the query.
-	$args['post__not_in'] = se_get_dates_from_non_published_events();
+	$args['post__not_in'] = se_get_date_ids_for_non_published_events();
 
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
@@ -527,7 +527,7 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 	return $previous_event;
 }
 
-if ( ! function_exists( 'se_get_dates_from_non_published_events' ) ) {
+if ( ! function_exists( 'se_get_date_ids_for_non_published_events' ) ) {
 
 	/**
 	 * Return an array of all event dates, where the parent is not published.
@@ -536,7 +536,7 @@ if ( ! function_exists( 'se_get_dates_from_non_published_events' ) ) {
 	 *
 	 * @return int[]
 	 */
-	function se_get_dates_from_non_published_events() {
+	function se_get_date_ids_for_non_published_events() {
 		static $dates = null;
 		if ( is_array( $dates ) ) {
 			return $dates;

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -438,9 +438,11 @@ function se_event_get_next_event( int $event_id, ?int $event_date_id = null ): ?
 
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
-		$args['post__not_in'] = array_merge(
-			$args['post__not_in'],
-			array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
+		$args['post__not_in'] = array_unique(
+			array_merge(
+				$args['post__not_in'],
+				array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
+			)
 		);
 	}
 
@@ -507,9 +509,11 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
-		$args['post__not_in'] = array_merge(
-			$args['post__not_in'],
-			array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
+		$args['post__not_in'] = array_unique(
+			array_merge(
+				$args['post__not_in'],
+				array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
+			)
 		);
 	}
 

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -388,6 +388,7 @@ if ( ! function_exists( 'se_template_event_next_previous' ) ) {
 	}
 }
 
+
 /**
  * Gets the next event based on a time stamp.
  *
@@ -431,13 +432,15 @@ function se_event_get_next_event( int $event_id, ?int $event_date_id = null ): ?
 			),
 		),
 	);
+
+	// Ensure any events that are not published are not included in the query.
+	$args['post__not_in'] = se_get_dates_from_non_published_events();
+
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
-		$args['post__not_in'] = array_map(
-			function ( $post ) {
-				return $post['id'];
-			},
-			se_event_get_event_dates( $event_id )
+		$args['post__not_in'] = array_merge(
+			$args['post__not_in'],
+			array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
 		);
 	}
 
@@ -498,13 +501,15 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 			),
 		),
 	);
+
+	// Ensure any events that are not published are not included in the query.
+	$args['post__not_in'] = se_get_dates_from_non_published_events();
+
 	// If we dont allow grouping, add the event id to parent not in.
 	if ( ! $allow_grouping ) {
-		$args['post__not_in'] = array_map(
-			function ( $post ) {
-				return $post['id'];
-			},
-			se_event_get_event_dates( $event_id )
+		$args['post__not_in'] = array_merge(
+			$args['post__not_in'],
+			array_map( fn( array $date ): int => $date['id'], se_event_get_event_dates( $event_id ) )
 		);
 	}
 
@@ -520,6 +525,45 @@ function se_event_get_previous_event( int $event_id, ?int $event_date_id = null 
 	wp_reset_postdata();
 
 	return $previous_event;
+}
+
+if ( ! function_exists( 'se_get_dates_from_non_published_events' ) ) {
+
+	/**
+	 * Return an array of all event dates, where the parent is not published.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @return int[]
+	 */
+	function se_get_dates_from_non_published_events() {
+		static $dates = null;
+		if ( is_array( $dates ) ) {
+			return $dates;
+		}
+
+		// Get all events that not published (draft or pending or private).
+		$args        = array(
+			'post_type'      => SE_Event_Post_Type::$post_type,
+			'post_status'    => array_diff( get_post_stati(), array( 'publish' ) ),
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+		);
+		$draft_dates = get_posts( $args );
+
+		$dates = array();
+
+		foreach ( $draft_dates as $draft_date ) {
+			// Get all dates for this event.
+			$event_dates = se_event_get_event_dates( $draft_date );
+			if ( ! empty( $event_dates ) ) {
+				foreach ( $event_dates as $date ) {
+					$dates[] = $date['id'];
+				}
+			}
+		}
+		return $dates;
+	}
 }
 
 if ( ! function_exists( 'se_expired_event_notice' ) ) {

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -532,7 +532,7 @@ if ( ! function_exists( 'se_get_date_ids_for_non_published_events' ) ) {
 	/**
 	 * Return an array of all event dates, where the parent is not published.
 	 *
-	 * @since 2.0.0
+	 * @since 2.0.4
 	 *
 	 * @return int[]
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensure that the $template_fallback exists before its called.
* When we search for the next/previous events, we should ensure that ignore any event dates where the event is not published. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an event, add a few dates, then set the event as draft.  - E1
* Create another event a day after and set as published           - E2
* Create another event a day before and set as published          - E3

When you are E2, NO next event, but the previous should be E3
When you are on E3, Next should be E2 and no pevious.

E1 should never show, unless made public

Mentions #35 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Next/Previous event navigation now correctly skips non-published events, so navigation only surfaces visible events.
  - When grouping is disabled, navigation excludes all dates of the current event for more accurate previous/next results.
  - Resolved occasional undefined-variable notices during template resolution, improving site stability and reducing notice output for visitors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->