### PR TITLE
Control the flow based on fse theme or not, to avoid accidently using…

### DIFF
--- a/src/classes/class-se-template-loader.php
+++ b/src/classes/class-se-template-loader.php
@@ -30,6 +30,10 @@ class SE_Template_Loader {
 	 * @return string
 	 */
 	public static function template_include( $template ) {
+		if ( wp_is_block_theme() && str_contains( $template, 'template-canvas.php' ) ) {
+			return $template;
+		}
+
 		// Check if we are looking for a single event or event date template.
 		if ( is_single() && get_post_type() === SE_Event_Post_Type::$post_type ) {
 			// Attempt to look for the single event template in themes etc.

--- a/src/template-functions.php
+++ b/src/template-functions.php
@@ -637,12 +637,15 @@ if ( ! function_exists( 'se_fix_se_events_fse_archive_template' ) ) {
 	function se_fix_se_events_fse_archive_template( $templates ) {
 		if ( 'se-event-date' === get_query_var( 'post_type' ) ) {
 			// Create proper hierarchy: archive-se-events.html, then archive.html
-			$custom_hierarchy = array(
+			$custom_hierarchy_fse    = array(
 				'archive-se-event.html',
 				'archive.html',
 			);
-
-			return $custom_hierarchy;
+			$custom_hierarchy_legacy = array(
+				'archive-se-event.php',
+				'archive.php',
+			);
+			return wp_is_block_theme() ? $custom_hierarchy_fse : $custom_hierarchy_legacy;
 		}
 		return $templates;
 	}


### PR DESCRIPTION
… event archives on non event archives

#### Changes proposed in this Pull Request

* Ensure that php template logic is ignored if an FSE theme
* Ensure that we try to find archives as .html or .php nased on block theme.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with WordPress block (FSE) themes by no longer intercepting the theme’s canvas template, ensuring native rendering is preserved.
  * Corrected event archive template resolution to automatically choose the proper hierarchy for block vs. classic themes, delivering consistent layouts across environments.
  * Non-block themes retain existing behavior, avoiding regressions and ensuring stable template loading for single events, date-based archives, and other views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->