### PR TITLE
now if non html is used and we are hiding both the start and end time…

### DIFF
--- a/src/classes/class-date-display-formatter.php
+++ b/src/classes/class-date-display-formatter.php
@@ -354,6 +354,7 @@ class SE_Date_Display_Formatter {
 			$output .= $this->render_date_list_ungrouped( $event_dates );
 		}
 
+
 		$output .= $this->use_html_in_date_output ? '</ul>' : '';
 		return $output;
 	}
@@ -498,6 +499,12 @@ class SE_Date_Display_Formatter {
 					$output .= '<div class="se-event-date-list-item__grouped-time">';
 				}
 				$output .= $this->date_only ? '' : $time_label;
+
+
+				// If the output ends ' - ', remove it.
+				$output = rtrim( $output, ' - ' );
+
+
 				if ( $this->use_html_in_date_output ) {
 					$output .= '</div>';
 

--- a/src/classes/class-date-display-formatter.php
+++ b/src/classes/class-date-display-formatter.php
@@ -354,7 +354,6 @@ class SE_Date_Display_Formatter {
 			$output .= $this->render_date_list_ungrouped( $event_dates );
 		}
 
-
 		$output .= $this->use_html_in_date_output ? '</ul>' : '';
 		return $output;
 	}
@@ -447,7 +446,9 @@ class SE_Date_Display_Formatter {
 		// Iterate over each group, and break them down to the starting month.
 		foreach ( $groups as $group ) {
 			// Create the time label.
+
 			$time_label = $group[0]['all_day'] ? SE_Settings::get_all_day_message() : null;
+
 			if ( ! $time_label ) {
 				$time_start = ( $this->hide_start_time ) ? '' : $this->format_time( $group[0]['start_date'] );
 				$time_end   = ( $this->hide_end_time ) ? '' : $this->format_time( $group[0]['end_date'] );
@@ -500,10 +501,8 @@ class SE_Date_Display_Formatter {
 				}
 				$output .= $this->date_only ? '' : $time_label;
 
-
 				// If the output ends ' - ', remove it.
 				$output = rtrim( $output, ' - ' );
-
 
 				if ( $this->use_html_in_date_output ) {
 					$output .= '</div>';
@@ -533,7 +532,7 @@ class SE_Date_Display_Formatter {
 	 * @return string
 	 */
 	private function join_string( array $items, string $separator, string $separator_end ) {
-		// If arrray only contains one item, return it.
+		// If array only contains one item, return it.
 		if ( count( $items ) === 1 ) {
 			return $items[0];
 		}


### PR DESCRIPTION
…s, the trailing - is removed

#### Changes proposed in this Pull Request

* When an event is made that has multiple dates, shows the dates grouped, hides the start and end times plus used the non HTML date renderings i would leave a trailing ` - `, this has now been removed.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Before
<img width="557" height="218" alt="image" src="https://github.com/user-attachments/assets/c134c051-5827-4ec8-a647-fccd732b7043" />

* After
<img width="546" height="210" alt="image" src="https://github.com/user-attachments/assets/bf92019b-7545-4076-8f2a-36dbbcecb939" />


Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Grouped date displays no longer show a trailing dash when no time label exists.
  - Grouped items now correctly display an appropriate time label (including an "all day" message) when applicable; ungrouped views unchanged.

- **Documentation**
  - Fixed a minor doc-comment typo for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->