### PR TITLE
reinstate se_event_get_dates() for legacy sites

### DIFF
--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -118,18 +118,32 @@ function se_event_get_tickets_stock( $event_id ) {
  * Get event dates.
  *
  * @param integer $event_id    Event id.
- * @param array   $event_dates Event dates.
+ * @param array   $event_dates Event dates, not used.
  *
  * @deprecated 2.0.0 Please use the new se_event_get_event_dates() instead.
  *
- * @return mixed
+ * @return array<int, array{datetime_start:int, datetime_end:int, all_day:boolean}> Event dates.
  */
 function se_event_get_dates( $event_id, $event_dates = null ) {
-	_deprecated_function( __FUNCTION__, 'Please use the new se_event_get_event_dates() instead.', '2.0.0' );
+
+	// Get dates in new format.
+	$dates = se_event_get_event_dates( $event_id );
+
+	// Map to old format.
+	$dates = array_map(
+		function ( $date ) {
+			return array(
+				'datetime_start' => $date['start_date'],
+				'datetime_end'   => $date['end_date'],
+				'all_day'        => $date['all_day'],
+			);
+		},
+		$dates
+	);
 
 	return apply_filters(
 		'se_event_get_dates',
-		se_event_get_event_dates( $event_id, $event_dates ),
+		$dates,
 		$event_id
 	);
 }
@@ -750,9 +764,6 @@ function se_event_get_event_dates( $event_id ): array {
 		},
 		$event_dates
 	);
-
-	// Legacy filter.
-	$dates = apply_filters( 'se_event_get_dates', $dates, $event_id );
 
 	return apply_filters( 'se_event_get_event_dates', $dates, $event_id );
 }

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -124,7 +124,7 @@ function se_event_get_tickets_stock( $event_id ) {
  *
  * @return array<int, array{datetime_start:int, datetime_end:int, all_day:boolean}> Event dates.
  */
-function se_event_get_dates( $event_id, $event_dates = null ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingFunction.Found
+function se_event_get_dates( $event_id, $event_dates = null ) { // phpcs:ignore 
 
 	// Get dates in new format.
 	$dates = se_event_get_event_dates( $event_id );

--- a/src/event-functions.php
+++ b/src/event-functions.php
@@ -124,7 +124,7 @@ function se_event_get_tickets_stock( $event_id ) {
  *
  * @return array<int, array{datetime_start:int, datetime_end:int, all_day:boolean}> Event dates.
  */
-function se_event_get_dates( $event_id, $event_dates = null ) {
+function se_event_get_dates( $event_id, $event_dates = null ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingFunction.Found
 
 	// Get dates in new format.
 	$dates = se_event_get_event_dates( $event_id );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates legacy date handling in the event functions to better align with the new event date format and improve backward compatibility. The main focus is on ensuring that the deprecated `se_event_get_dates` function returns data in the expected legacy structure while internally using the new `se_event_get_event_dates` function.

**Legacy compatibility and function updates:**

* Updated the `se_event_get_dates` function to internally call `se_event_get_event_dates`, then map the results to the legacy format expected by older code. The function now returns an array of associative arrays with `datetime_start`, `datetime_end`, and `all_day` keys, ensuring compatibility for code relying on the old structure.
* Removed the redundant legacy filter (`se_event_get_dates`) from the `se_event_get_event_dates` function to avoid double filtering and maintain a single source of truth for event date data.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sites with custom functionality that works with dates, will now be able to continue with old syntax, as we map to the old structure 

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Switched event date handling to a single modern format with automatic translation for older integrations, improving consistency and reliability.
  - Removed deprecated legacy pathways to reduce ambiguity and conflicts in date processing.

- Documentation
  - Clarified parameter usage and specified the exact return structure for event date data to aid developers.

- Chores
  - Removed obsolete legacy filters and cleaned up related routing to align with current standards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->