### PR TITLE
Now the date will work first time. If you set the start date after th…

### DIFF
--- a/src/blocks/event-info/components/DateTimeGroup.js
+++ b/src/blocks/event-info/components/DateTimeGroup.js
@@ -89,7 +89,6 @@ const DateTimeGroupNew = ({
 		const newDate = tempEventDate || dateInstance || (isStartChange ? eventStart : eventEnd);
 		const newTime = tempEventTime || dateInstance || (isStartChange ? eventStart : eventEnd);
 
-
 		// Combine the new date and time and convert to a timestamp.
 		const newDateTime = getTimestamp(
 			combineDateAndTime(newDate, newTime),
@@ -97,7 +96,6 @@ const DateTimeGroupNew = ({
 		);
 
 		const newEventDateTime = clone(currentEventDateTime);
-
 
 		if (isStartChange) {
 			newEventDateTime.start_date = newDateTime;

--- a/src/blocks/event-info/components/DateTimeGroup.js
+++ b/src/blocks/event-info/components/DateTimeGroup.js
@@ -82,12 +82,13 @@ const DateTimeGroupNew = ({
 			return;
 		}
 
-		const newDate =
-			tempEventDate ||
-			(isStartChange ? eventStart : eventEnd);
-		const newTime =
-			tempEventTime ||
-			(isStartChange ? eventStart : eventEnd);
+		// Get the full date time instance from either temp date or time.
+		const dateInstance = tempEventDate ? tempEventDate : tempEventTime;
+
+		// Set the new date and time based on what was changed.
+		const newDate = tempEventDate || dateInstance || (isStartChange ? eventStart : eventEnd);
+		const newTime = tempEventTime || dateInstance || (isStartChange ? eventStart : eventEnd);
+
 
 		// Combine the new date and time and convert to a timestamp.
 		const newDateTime = getTimestamp(
@@ -96,6 +97,7 @@ const DateTimeGroupNew = ({
 		);
 
 		const newEventDateTime = clone(currentEventDateTime);
+
 
 		if (isStartChange) {
 			newEventDateTime.start_date = newDateTime;

--- a/src/classes/class-date-display-formatter.php
+++ b/src/classes/class-date-display-formatter.php
@@ -675,8 +675,8 @@ class SE_Date_Display_Formatter {
 			// For all day events, just show the date (or date range if different days).
 			if ( ! $same_day ) {
 				$output .= ' &ndash; ' . $end_date . ' ' . SE_Settings::get_all_day_message();
-			} else {
-				$output .= ' ' . SE_Settings::get_all_day_message();
+			} elseif ( ! $this->date_only ) {
+					$output .= ' ' . SE_Settings::get_all_day_message();
 			}
 		} elseif ( $same_day ) {
 			// Same day event with times.
@@ -703,7 +703,7 @@ class SE_Date_Display_Formatter {
 		}
 
 		// Add timezone if the option is set.
-		if ( $this->display_timezone ) {
+		if ( $this->display_timezone && ! $this->time_only && ! $is_all_day ) {
 			$output .= ' (' . $this->get_timezone_abbreviation() . ')';
 		}
 


### PR DESCRIPTION
…e end date, the end date is set 1 hour after the start date. if end date is set before the start date, the start date is updated to 1hr before the end time.

Add a few pending changes around how we display timezones

#### Changes proposed in this Pull Request

Ensure that the fully date/time instance is use when we first set the date time. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #49 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed all-day event label display to show only in relevant contexts
  * Refined timezone abbreviation visibility based on event settings

* **Refactor**
  * Improved date and time selection logic for enhanced consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->