### PR TITLE
Ensure that the filters are not used when the calendar is used on an …

### DIFF
--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -767,6 +767,11 @@ class SE_Blocks {
 		$previous_date_time = SE_Calendar::get_instance()->get_previous_month_with_events( $current_date_time );
 		$next_date_time     = SE_Calendar::get_instance()->get_next_month_with_events( $current_date_time );
 
+		// If this being loaded on an archive page, ensure event query filters are removed.
+		if ( is_archive() && in_array( get_post_type(), array( SE_Event_Post_Type::$post_type, SE_Event_Post_Type::$event_date_post_type ), true ) ) {
+			SE_Event_Query_Utils::remove_event_query_filters();
+		}
+
 		$current_date = $current_date_time->format( 'Y-m-01' );
 		$month_data   = SE_Calendar::get_instance()->get_month_days( $current_date );
 


### PR DESCRIPTION
…archive page

#### Changes proposed in this Pull Request

This pull request introduces an important improvement to the event calendar rendering logic by ensuring that event query filters are properly removed when the calendar is rendered on archive pages. This helps prevent conflicts and ensures accurate event listings in archive contexts.

Query filter management:

* Ensured that event query filters are removed when rendering the calendar on archive pages for event post types, preventing unwanted filtering and improving compatibility with archive views.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar rendering on event archive pages to properly clear filters and ensure correct display of events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->