### PR TITLE
Fix `is_archive()` checks

### DIFF
--- a/src/classes/class-se-template-loader.php
+++ b/src/classes/class-se-template-loader.php
@@ -56,7 +56,7 @@ class SE_Template_Loader {
 		}
 
 		// Handle taxonomy archives for event categories.
-		if ( is_archive( 'se-event-category' ) ) {
+		if ( is_tax( 'se-event-category' ) ) {
 			$theme_templates = array(
 				'archive-se-event.php',
 			);
@@ -105,7 +105,7 @@ class SE_Template_Loader {
 
 		// Determine if standard se-event archive templates are available in the theme
 		// before replacing with the custom template in this plugin.
-		if ( is_archive( 'se-event-date' ) ) {
+		if ( is_post_type_archive( 'se-event-date' ) ) {
 			$theme_templates = array(
 				'archive-se-event.php',
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `is_archive( 'se-event-category' )` with `is_tax( 'se-event-category' )`, and `is_archive( 'se-event-date' )` with `is_post_type_archive( 'se-event-date' )`.

The `is_archive()` function doesn't accept any parameters, so it's returning `true` for any archive view.

Mentions https://github.com/a8cteam51/bfi/issues/812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template detection for event category and event date archive pages to ensure proper page rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->