### PR TITLE
Bumped

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     2.0.9
+ * @version     2.0.10
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -11,9 +11,9 @@
  * Plugin Name:             Simple Events
  * Plugin URI:              https://wpspecialprojects.wordpress.com
  * Description:             Event management frontend for WooCommerce Box Office.
- * Requires at least:       6.2
- * Tested up to:            6.4
- * Version:                 2.0.9
+ * Requires at least:       6.5
+ * Tested up to:            6.9
+ * Version:                 2.0.10
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '2.0.9' );
+define( 'SE_VERSION', '2.0.10' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request updates the plugin metadata and version constants in `plugin.php` to reflect the new release of the Simple Events plugin. It also updates the minimum and tested WordPress versions.

Version and compatibility updates:

* Bumped the plugin version from `2.0.9` to `2.0.10` in both the plugin header and the `SE_VERSION` constant. [[1]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L6-R16) [[2]](diffhunk://#diff-63e630aa779572c3d4c2bc7edf2dc6ae2da5e6719b1495ab2682fdc983bc2d96L34-R34)
* Updated the "Requires at least" WordPress version to `6.5` and "Tested up to" version to `6.9` in the plugin header.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.0.10
  * WordPress compatibility requirements updated: minimum version 6.5, tested up to 6.9

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->