### PR TITLE
Adds check to ensure that all hidden events are excluded from the check

### DIFF
--- a/src/classes/class-se-block-variations.php
+++ b/src/classes/class-se-block-variations.php
@@ -144,9 +144,10 @@ class SE_Block_Variations {
 	private function set_event_query_args( $args, $feed_type, $feed_order = 'ASC' ) {
 
 		// If we are ordering by desc. we need to sort by end date, else start.
-		$args['meta_key'] = 'desc' === strtolower( $feed_order ) ? 'se_event_date_end' : 'se_event_date_start';
-		$args['orderby']  = 'meta_value';
-		$args['order']    = $feed_order;
+		$args['meta_key']    = 'desc' === strtolower( $feed_order ) ? 'se_event_date_end' : 'se_event_date_start';
+		$args['orderby']     = 'meta_value';
+		$args['order']       = $feed_order;
+		$args['post_status'] = 'publish';
 
 		$args['sub-type'] = self::QUERY_LOOP_EVENTS;
 

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -118,11 +118,13 @@ class SE_Event_Query_Utils {
 		}
 
 		// Subquery to get the correct post ID for each parent based on sort order
+		// Also ensures the parent event post is published.
 		$subquery = "
 			AND {$wpdb->posts}.ID IN (
 				SELECT p1.ID
 				FROM {$wpdb->posts} p1
 				INNER JOIN {$wpdb->postmeta} pm1 ON p1.ID = pm1.post_id AND pm1.meta_key = '{$meta_key}'
+				INNER JOIN {$wpdb->posts} parent ON p1.post_parent = parent.ID AND parent.post_status = 'publish'
 				WHERE p1.post_type = '" . SE_Event_Post_Type::$event_date_post_type . "'
 				AND p1.post_status = 'publish'
 				AND pm1.meta_value = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request focuses on improving the reliability of event queries by ensuring that only published events and their published parent events are included in query results. The changes help prevent unpublished or draft events from appearing in feeds or queries.

**Event query improvements:**

* Added a filter to ensure only published events are returned by explicitly setting the `post_status` to `'publish'` in the event query arguments in `class-se-block-variations.php`.
* Updated the subquery in `filter_unique_parents_where` to require that parent event posts are also published, preventing unpublished parent events from being included in results in `class-se-event-query-utils.php`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #
