### PR TITLE
Fix fatal error when parent event post is deleted

### DIFF
--- a/src/classes/class-se-block-variations.php
+++ b/src/classes/class-se-block-variations.php
@@ -194,7 +194,7 @@ class SE_Block_Variations {
 		$args['unique_parents'] = true;
 		$args['feed_order']     = $feed_order; // Store feed order for use in the WHERE filter
 		// Ensure we only get the correct event date for each parent.
-		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_unique_parents_where' ), 10, 2 );
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 
 		// Add a filter to modify the posts results.
 		add_filter( 'the_posts', array( 'SE_Event_Query_Utils', 'modify_event_posts' ), 10, 2 );

--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -589,7 +589,7 @@ class SE_Blocks {
 				$events_query_args['feed_order']     = $feed_order;
 
 				// Add filter for unique parents WHERE clause
-				add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_unique_parents_where' ), 10, 2 );
+				add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 			}
 
 			$show_year_dividers = ! empty( $attributes['showYearDividers'] );
@@ -632,7 +632,7 @@ class SE_Blocks {
 
 			// Clean up filters
 			if ( ! se_event_treat_each_date_as_own_event() ) {
-				remove_filter( 'posts_where', array( __CLASS__, 'filter_unique_parents_where' ), 10 );
+				remove_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10 );
 				remove_filter( 'the_posts', array( __CLASS__, 'modify_event_posts_for_blocks' ), 10 );
 			}
 

--- a/src/classes/class-se-event-post-type.php
+++ b/src/classes/class-se-event-post-type.php
@@ -636,7 +636,7 @@ class SE_Event_Post_Type {
 				$query->set( 'feed_order', $sort_order );
 
 				// Add filter for unique parents WHERE clause
-				add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_unique_parents_where' ), 10, 2 );
+				add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 
 				// Add filter to modify posts for event_date_id
 				add_filter( 'the_posts', array( 'SE_Event_Query_Utils', 'modify_event_posts' ), 10, 2 );

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -182,32 +182,38 @@ class SE_Event_Query_Utils {
 		}
 
 		// Return back the modified posts with parent info and event_date_id
-		return array_map(
-			function ( $post ) {
-				$parent = get_post( $post->post_parent );
+		return array_filter(
+			array_map(
+				function ( $post ) {
+					$parent = get_post( $post->post_parent );
 
-				// Get the start date from the event.
-				$start_date_ts = get_post_meta( $post->ID, 'se_event_date_start', true );
+					if ( ! $parent ) {
+						return null;
+					}
 
-				// Get the event timezone.
-				$timezone = get_post_meta( $parent->ID, 'se_event_timezone', true );
-				// use the timezone or default to the site timezone.
-				$timezone = $timezone ? $timezone : wp_timezone_string();
+					// Get the start date from the event.
+					$start_date_ts = get_post_meta( $post->ID, 'se_event_date_start', true );
 
-				// Get the date in this format 2025-07-01 13:14:09
-				$start_date     = wp_date( 'Y-m-d H:i:s', $start_date_ts, new \DateTimeZone( $timezone ) );
-				$start_date_gmt = wp_date( 'Y-m-d H:i:s', $start_date_ts, new \DateTimeZone( 'UTC' ) );
+					// Get the event timezone.
+					$timezone = get_post_meta( $parent->ID, 'se_event_timezone', true );
+					// use the timezone or default to the site timezone.
+					$timezone = $timezone ? $timezone : wp_timezone_string();
 
-				// update the parent posts post date
-				$parent->post_date         = $start_date;
-				$parent->post_date_gmt     = $start_date_gmt;
-				$parent->post_modified     = $start_date;
-				$parent->post_modified_gmt = $start_date_gmt;
-				$parent->event_date_id     = $post->ID;
+					// Get the date in this format 2025-07-01 13:14:09
+					$start_date     = wp_date( 'Y-m-d H:i:s', $start_date_ts, new \DateTimeZone( $timezone ) );
+					$start_date_gmt = wp_date( 'Y-m-d H:i:s', $start_date_ts, new \DateTimeZone( 'UTC' ) );
 
-				return $parent;
-			},
-			$posts
+					// update the parent posts post date
+					$parent->post_date         = $start_date;
+					$parent->post_date_gmt     = $start_date_gmt;
+					$parent->post_modified     = $start_date;
+					$parent->post_modified_gmt = $start_date_gmt;
+					$parent->event_date_id     = $post->ID;
+
+					return $parent;
+				},
+				$posts
+			)
 		);
 	}
 

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -72,25 +72,33 @@ class SE_Event_Query_Utils {
 	}
 
 	/**
-	 * Filter posts to only include the correct event date for each parent.
+	 * Filter event date queries to ensure parent events are published,
+	 * and optionally include only the correct event date for each parent.
 	 *
 	 * @param string   $where The WHERE clause of the query.
 	 * @param WP_Query $query The WP_Query instance.
 	 *
 	 * @return string
 	 */
-	public static function filter_unique_parents_where( $where, $query ) {
-		// Check if this is our events query and unique parents is enabled
-		if ( ! isset( $query->query_vars['unique_parents'] ) || ! isset( $query->query_vars['feed_order'] ) ) {
-			return $where;
-		}
-
-		// Skip if treating each date as own event
-		if ( se_event_treat_each_date_as_own_event() ) {
+	public static function filter_event_dates_where( $where, $query ) {
+		// Only apply to event date queries.
+		if ( SE_Event_Post_Type::$event_date_post_type !== $query->get( 'post_type' ) ) {
 			return $where;
 		}
 
 		global $wpdb;
+
+		// Always ensure the parent event post is published.
+		$where .= " AND {$wpdb->posts}.post_parent IN (
+			SELECT ID FROM {$wpdb->posts}
+			WHERE post_type = '" . SE_Event_Post_Type::$post_type . "'
+			AND post_status = 'publish'
+		)";
+
+		// If treating each date as own event or unique_parents not set, skip the unique parents subquery.
+		if ( se_event_treat_each_date_as_own_event() || ! isset( $query->query_vars['unique_parents'] ) || ! isset( $query->query_vars['feed_order'] ) ) {
+			return $where;
+		}
 
 		$feed_order = $query->query_vars['feed_order'];
 		$meta_key   = 'desc' === strtolower( $feed_order ) ? 'se_event_date_end' : 'se_event_date_start';
@@ -117,7 +125,7 @@ class SE_Event_Query_Utils {
 			}
 		}
 
-		// Subquery to get the correct post ID for each parent based on sort order
+		// Subquery to get the correct post ID for each parent based on sort order.
 		$subquery = "
 			AND {$wpdb->posts}.ID IN (
 				SELECT p1.ID
@@ -187,10 +195,6 @@ class SE_Event_Query_Utils {
 				function ( $post ) {
 					$parent = get_post( $post->post_parent );
 
-					if ( ! $parent ) {
-						return null;
-					}
-
 					// Get the start date from the event.
 					$start_date_ts = get_post_meta( $post->ID, 'se_event_date_start', true );
 
@@ -253,7 +257,7 @@ class SE_Event_Query_Utils {
 			$query->set( 'feed_order', $feed_order );
 
 			// Add filter for unique parents WHERE clause
-			add_filter( 'posts_where', array( __CLASS__, 'filter_unique_parents_where' ), 10, 2 );
+			add_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10, 2 );
 
 			// Add filter to modify posts
 			add_filter( 'the_posts', array( __CLASS__, 'modify_event_posts' ), 10, 2 );
@@ -277,7 +281,7 @@ class SE_Event_Query_Utils {
 	public static function remove_event_query_filters( $context = 'archive' ) { // phpcs:ignore
 		// Remove filters based on context
 		if ( ! se_event_treat_each_date_as_own_event() ) {
-			remove_filter( 'posts_where', array( __CLASS__, 'filter_unique_parents_where' ), 10 );
+			remove_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10 );
 			remove_filter( 'posts_orderby', array( __CLASS__, 'fix_sort_order' ), 10 );
 		}
 


### PR DESCRIPTION
### Summary

- Fixes a PHP fatal error (`Attempt to assign property "post_date" on null`) in `SE_Event_Query_Utils::modify_event_posts()` that crashes the site when an event is deleted but its child `se-event-date` posts still exist in the database.
- Adds a null check for the parent post and wraps `array_map` in `array_filter` to skip orphaned event-date posts gracefully.

### Problem

When an `se-event` post is deleted, its child `se-event-date` posts can remain in the database. On the next page load that queries events (archive, calendar, post template block, etc.), `get_post( $post->post_parent )` returns `null`, and the code immediately tries to set properties on it — causing a fatal error that takes the entire site down.

### Changes

**`src/classes/class-se-event-query-utils.php`**

- Added a null check after `get_post()` — if the parent post doesn't exist, return `null`.
- Wrapped `array_map` in `array_filter` to remove the `null` entries, so orphaned event-date posts are silently excluded from query results.

### Test plan

- [x] Delete an event that has associated `se-event-date` child posts.
- [x] Visit the site frontend (archive, calendar, or any page with a post template block querying events).
- [x] Confirm the page loads without a fatal error and the deleted event no longer appears.
- [x] Confirm existing events with valid parent posts still display correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized event date filtering logic to improve query performance and accuracy when displaying events. Internal restructuring of event query filters to better handle event date processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->