### PR TITLE
Fix/null parent fatal in modify event posts

### DIFF
--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -632,8 +632,8 @@ class SE_Blocks {
 
 			// Clean up filters
 			if ( ! se_event_treat_each_date_as_own_event() ) {
-				remove_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10 );
-				remove_filter( 'the_posts', array( __CLASS__, 'modify_event_posts_for_blocks' ), 10 );
+				remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
+				remove_filter( 'the_posts', array( 'SE_Event_Query_Utils', 'modify_event_posts' ), 10 );
 			}
 
 			wp_reset_postdata();

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -195,6 +195,11 @@ class SE_Event_Query_Utils {
 				function ( $post ) {
 					$parent = get_post( $post->post_parent );
 
+					// If we can't get the parent for some reason, return the original post to avoid breaking things, even though it likely won't display correctly.
+					if ( ! $parent ) {
+						return null;
+					}
+
 					// Get the start date from the event.
 					$start_date_ts = get_post_meta( $post->ID, 'se_event_date_start', true );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Addresses issues in previous PR https://github.com/a8cteam51/simple-events/pull/64

This pull request makes targeted improvements to event query handling, focusing on correct filter cleanup and increased robustness when processing event posts. The most significant changes are:

**Filter cleanup and event query handling:**

* In `class-se-blocks.php`, the filters for `posts_where` and `the_posts` are now removed using the correct class and method references (`SE_Event_Query_Utils::filter_event_dates_where` and `SE_Event_Query_Utils::modify_event_posts`), ensuring proper cleanup after event queries.

**Robustness improvements in event post processing:**

* In `class-se-event-query-utils.php`, a null check was added when retrieving a post's parent in `modify_event_posts`. If the parent cannot be found, the function now returns `null` for that post, preventing errors and avoiding breaking the event display.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal event query utilities for improved code organization and maintainability
  * Enhanced post processing with additional safeguards to improve system stability when handling edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->