### PR TITLE
Improve auto update functionality with suggestions from coderabbit

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -88,18 +88,57 @@ add_filter(
 			return $update;
 		}
 
-		$latest_release_info = wp_remote_get( 'https://api.github.com/repos/a8cteam51/simple-events/releases/latest' );
-		if ( is_wp_error( $latest_release_info ) || 200 !== wp_remote_retrieve_response_code( $latest_release_info ) ) {
+		$latest_release_info = get_site_transient( 'se_latest_release_info' );
+		if ( false === $latest_release_info ) {
+			$response = wp_remote_get(
+				'https://api.github.com/repos/a8cteam51/simple-events/releases/latest',
+				array(
+					'timeout' => 10,
+					'headers' => array(
+						'Accept' => 'application/vnd.github+json',
+					),
+				)
+			);
+			if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				return $update;
+			}
+			$latest_release_info = wp_remote_retrieve_body( $response );
+			set_site_transient( 'se_latest_release_info', $latest_release_info, HOUR_IN_SECONDS );
+		}
+
+		if ( empty( $latest_release_info ) ) {
 			return $update;
 		}
-		$latest_release_info    = json_decode( wp_remote_retrieve_body( $latest_release_info ), true );
+
+		$latest_release_info = json_decode( $latest_release_info, true );
+		if (
+			! is_array( $latest_release_info ) ||
+			empty( $latest_release_info['tag_name'] ) ||
+			empty( $latest_release_info['html_url'] ) ||
+			empty( $latest_release_info['assets'] ) ||
+			! is_array( $latest_release_info['assets'] )
+		) {
+			return $update;
+		}
+
+		$package_url = '';
+		foreach ( $latest_release_info['assets'] as $asset ) {
+			if ( ! empty( $asset['browser_download_url'] ) && str_ends_with( $asset['browser_download_url'], '.zip' ) ) {
+				$package_url = $asset['browser_download_url'];
+				break;
+			}
+		}
+		if ( '' === $package_url ) {
+			return $update;
+		}
+
 		$latest_release_version = ltrim( $latest_release_info['tag_name'], 'v' );
 		if ( version_compare( $plugin_data['Version'], $latest_release_version, '<' ) ) {
 			$update = array(
 				'slug'    => $plugin_data['TextDomain'],
 				'version' => $latest_release_version,
 				'url'     => $latest_release_info['html_url'],
-				'package' => $latest_release_info['assets'][0]['browser_download_url'],
+				'package' => $package_url,
 			);
 		} else {
 			$update = false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull request improves the plugin update mechanism by adding caching and more robust handling of GitHub release data. The main focus is on reducing unnecessary API calls and ensuring the correct release asset is used for updates.

**Performance and reliability improvements:**

* Added caching of the latest GitHub release info using a site transient (`se_latest_release_info`) to reduce API requests and improve performance.
* Improved error handling by checking for empty or invalid release data before proceeding with the update logic.

**Update asset selection:**

* Updated logic to select the correct `.zip` asset from the release's assets array, instead of assuming the first asset is always the correct one.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update checking reliability with enhanced validation of release information.
  * Fixed asset handling to properly select package files for updates.

* **Performance**
  * Optimized update checks with caching, reducing repeated API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->