### PR TITLE
Improve calendar navigation UX with loading skeleton and optional sequential months

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,41 @@ add_filter('se_event_calendar_link_text', function( string $link_text ) {
 }, 10, 1);
 ```
 
+### Calendar Rendering
+
+#### Filter day events before calendar markup is built
+```php
+add_filter( 'simple_events_calendar_day_events', function( array $day_events, DateTime $date, int $start_timestamp, int $end_timestamp ) {
+	$unique_events = array();
+	$seen_keys     = array();
+
+	foreach ( $day_events as $event ) {
+		if ( ! is_object( $event ) || ! isset( $event->ID, $event->event_start_date, $event->event_end_date ) ) {
+			$unique_events[] = $event;
+			continue;
+		}
+
+		$key = implode(
+			'|',
+			array(
+				(string) $event->ID,
+				$event->event_start_date instanceof DateTime ? $event->event_start_date->format( 'U' ) : '',
+				$event->event_end_date instanceof DateTime ? $event->event_end_date->format( 'U' ) : '',
+			)
+		);
+
+		if ( isset( $seen_keys[ $key ] ) ) {
+			continue;
+		}
+
+		$seen_keys[ $key ] = true;
+		$unique_events[]   = $event;
+	}
+
+	return $unique_events;
+}, 10, 4 );
+```
+
 ### Cron Tasks for Event Start Date
 
 > When the cron task runs to update the event start date to a future date if its passed and future dates exist.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ Copy the `team51-focal-point` folder to your `mu-plugins` directory.
 
 ## Changelog
 
+### 2.1.2
+
+- **Calendar loading UX:** added a loading skeleton while calendar month requests are in flight.
+- **Calendar mobile interaction:** fixed day selection logic on mobile breakpoints when themes customize hidden/mobile display rules.
+- **Calendar navigation:** added a "Show Months in Order" option for sequential month navigation (defaults to off for existing blocks).
+
 ### 2.1.1
 
 - **Loop Event Info block:** added a configurable HTML wrapper element (`div`/`p`/`h1`–`h6`), per-block date and time format overrides, and a query offset control.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     2.1.1
+ * @version     2.1.2
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -14,7 +14,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.5
  * Tested up to:            6.9
- * Version:                 2.1.1
+ * Version:                 2.1.2
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '2.1.1' );
+define( 'SE_VERSION', '2.1.2' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/src/blocks/calendar/block.json
+++ b/src/blocks/calendar/block.json
@@ -39,6 +39,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"sequentialMonths": {
+			"type": "boolean",
+			"default": false
+		},
 		"hideNeighbourEvents": {
 			"type": "boolean",
 			"default": false

--- a/src/blocks/calendar/calendar.js
+++ b/src/blocks/calendar/calendar.js
@@ -45,18 +45,14 @@ export default class Calendar {
 	/**
 	 * Check if mobile view
 	 *
-	 * @param  calendarItem
 	 * @return {boolean}
 	 */
-	isMobile( calendarItem ) {
-		const mobileElements = calendarItem.querySelectorAll( this.DOM.desktopElements );
-		if ( mobileElements.length ) {
-			if ( 'none' === window.getComputedStyle( mobileElements[ 0 ], null ).display ) {
-				return true;
-			}
+	isMobile() {
+		if ( window.matchMedia ) {
+			return window.matchMedia( '(max-width: 767px)' ).matches;
 		}
 
-		return false;
+		return window.innerWidth <= 767;
 	}
 
 	/**
@@ -70,7 +66,7 @@ export default class Calendar {
 		if ( calendarDays.length ) {
 			calendarDays.forEach( ( item ) => {
 				item.addEventListener( 'click', ( event ) => {
-					if ( ! this.isMobile( calendarItem ) ) {
+					if ( ! this.isMobile() ) {
 						return;
 					}
 
@@ -135,12 +131,79 @@ export default class Calendar {
 	}
 
 	/**
+	 * Show loading skeleton and hide current calendar content.
+	 *
+	 * @param {Element} calendarItem Calendar container element.
+	 */
+	showLoading( calendarItem ) {
+		const skeleton = calendarItem.querySelector(
+			'[data-js="simple-events-calendar-skeleton"]'
+		);
+		const content = calendarItem.querySelector(
+			'[data-js="simple-events-calendar-content"]'
+		);
+
+		if ( skeleton ) {
+			skeleton.classList.remove(
+				'simple-events-calendar-skeleton--hidden'
+			);
+		}
+
+		if ( content ) {
+			content.classList.add( 'simple-events-calendar-content--hidden' );
+		}
+	}
+
+	/**
+	 * Update the visible calendar markup after request completes.
+	 *
+	 * @param {Element} calendarItem Calendar container element.
+	 * @param {string}  html         Updated calendar main HTML.
+	 */
+	updateContent( calendarItem, html ) {
+		const content = calendarItem.querySelector(
+			'[data-js="simple-events-calendar-content"]'
+		);
+
+		if ( content ) {
+			content.innerHTML = html;
+			return;
+		}
+
+		calendarItem.innerHTML = html;
+	}
+
+	/**
+	 * Hide loading skeleton and re-show calendar content.
+	 *
+	 * @param {Element} calendarItem Calendar container element.
+	 */
+	hideLoading( calendarItem ) {
+		const skeleton = calendarItem.querySelector(
+			'[data-js="simple-events-calendar-skeleton"]'
+		);
+		const content = calendarItem.querySelector(
+			'[data-js="simple-events-calendar-content"]'
+		);
+
+		if ( skeleton ) {
+			skeleton.classList.add( 'simple-events-calendar-skeleton--hidden' );
+		}
+
+		if ( content ) {
+			content.classList.remove( 'simple-events-calendar-content--hidden' );
+		}
+	}
+
+	/**
 	 * Send calendar API request
 	 *
 	 * @param date
 	 * @param calendarItem
 	 */
 	sendCalendarRequest( date, calendarItem ) {
+		this.showLoading( calendarItem );
+
 		/**
 		 * Convert GET request to POST
 		 * Implemented to send block attributes in body instead of URL.
@@ -154,12 +217,18 @@ export default class Calendar {
 			},
 		} ).then( ( result ) => {
 			if ( result.html ) {
-				calendarItem.innerHTML = result.html;
-				this.initListeners( calendarItem );
+				this.updateContent( calendarItem, result.html );
 			} else {
 				console.log( result );
 			}
-		});
+		} )
+			.catch( () => {
+				// Keep the existing calendar content if request fails.
+			} )
+			.finally( () => {
+				this.hideLoading( calendarItem );
+				this.initListeners( calendarItem );
+			} );
 	}
 
 	/**

--- a/src/blocks/calendar/index.js
+++ b/src/blocks/calendar/index.js
@@ -39,6 +39,20 @@ registerBlockType( 'simple-events/calendar', {
 				</BlockControls>
 				<InspectorControls>
 					<PanelBody title="Event Configuration" initialOpen={ true }>
+						<ToggleControl
+							label={ __(
+								'Show Months in Order',
+								'simple-events'
+							) }
+							help={ __(
+								'When enabled, months move one at a time and the calendar opens on the first month that has events (from today if the current month is empty). When disabled, navigation jumps only between months that have events.',
+								'simple-events'
+							) }
+							checked={ attributes?.sequentialMonths === true }
+							onChange={ ( value ) =>
+								setAttributes( { sequentialMonths: value } )
+							}
+						/>
 						<ToggleControl  
 							label={ __(
 								'Hide Events on Neighbouring Months',

--- a/src/blocks/calendar/style.scss
+++ b/src/blocks/calendar/style.scss
@@ -5,6 +5,91 @@
  */
 
 @import '../common.scss';
+
+.simple-events-calendar-skeleton {
+	&--hidden {
+		display: none;
+	}
+
+	&:not(.simple-events-calendar-skeleton--hidden) {
+		.simple-events-calendar-skeleton__top-bar > span,
+		.simple-events-calendar-skeleton__header > span,
+		.simple-events-calendar-skeleton__day {
+			background: linear-gradient(90deg, #454545 25%, #515151 50%, #454545 75%);
+			background-size: 200% 100%;
+			animation: simple-events-skeleton-shimmer 2.5s ease-in-out infinite;
+			border-radius: 4px;
+		}
+	}
+
+	.simple-events-calendar-skeleton__top-bar {
+		display: flex;
+		flex-direction: row;
+		gap: 20px;
+		align-items: center;
+		margin-bottom: 20px;
+
+		> span {
+			&:first-child {
+				width: 50px;
+				height: 28px;
+			}
+			&:nth-child(2) {
+				flex: 1;
+				max-width: 200px;
+				height: 28px;
+			}
+			&:nth-child(3) {
+				width: 80px;
+				height: 28px;
+			}
+		}
+	}
+
+	.simple-events-calendar-skeleton__header {
+		display: flex;
+		gap: 4px;
+		margin-bottom: 12px;
+
+		> span {
+			flex: 1;
+			height: 20px;
+		}
+	}
+
+	.simple-events-calendar-skeleton__body {
+		min-height: 500px;
+	}
+
+	.simple-events-calendar-skeleton__week {
+		display: flex;
+		gap: 4px;
+		margin-bottom: 4px;
+	}
+
+	.simple-events-calendar-skeleton__day {
+		flex: 1;
+		min-height: 100px;
+
+		@include max-mobile {
+			min-height: 50px;
+		}
+	}
+}
+
+@keyframes simple-events-skeleton-shimmer {
+	0% {
+		background-position: 200% 0;
+	}
+	100% {
+		background-position: -200% 0;
+	}
+}
+
+.simple-events-calendar-content--hidden {
+	display: none;
+}
+
 .simple-events-calendar {
     margin-left: auto;
     margin-right: auto;

--- a/src/blocks/calendar/style.scss
+++ b/src/blocks/calendar/style.scss
@@ -28,6 +28,7 @@
 		gap: 20px;
 		align-items: center;
 		margin-bottom: 20px;
+		justify-content: space-between;
 
 		> span {
 			&:first-child {

--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -763,9 +763,8 @@ class SE_Blocks {
 	 * @return HTML Calendar Template.
 	 */
 	public static function calendar_render( $attributes = array() ) {
-		$current_date_time  = SE_Calendar::get_instance()->create_date_time( 'now' );
-		$previous_date_time = SE_Calendar::get_instance()->get_previous_month_with_events( $current_date_time );
-		$next_date_time     = SE_Calendar::get_instance()->get_next_month_with_events( $current_date_time );
+		$sequential_months = isset( $attributes['sequentialMonths'] ) ? (bool) $attributes['sequentialMonths'] : false;
+		$current_date_time = SE_Calendar::get_instance()->create_date_time( 'now' );
 
 		// If this being loaded on an archive page, ensure event query filters are removed.
 		if ( is_archive() && in_array( get_post_type(), array( SE_Event_Post_Type::$post_type, SE_Event_Post_Type::$event_date_post_type ), true ) ) {
@@ -775,15 +774,34 @@ class SE_Blocks {
 		$current_date = $current_date_time->format( 'Y-m-01' );
 		$month_data   = SE_Calendar::get_instance()->get_month_days( $current_date );
 
-		if ( ! $month_data['month_has_events'] ) {
+		if ( $sequential_months && ! $month_data['month_has_events'] ) {
+			$first_event_month = SE_Calendar::get_instance()->get_next_month_with_events( $current_date_time, false );
+			if ( $first_event_month ) {
+				$current_date      = $first_event_month->format( 'Y-m-01' );
+				$month_data        = SE_Calendar::get_instance()->get_month_days( $current_date );
+				$current_date_time = SE_Calendar::get_instance()->create_date_time( $current_date );
+			} else {
+				$first_event_month = SE_Calendar::get_instance()->get_previous_month_with_events( $current_date_time, false );
+				if ( $first_event_month ) {
+					$current_date      = $first_event_month->format( 'Y-m-01' );
+					$month_data        = SE_Calendar::get_instance()->get_month_days( $current_date );
+					$current_date_time = SE_Calendar::get_instance()->create_date_time( $current_date );
+				}
+			}
+		}
+
+		$previous_date_time = SE_Calendar::get_instance()->get_previous_month_with_events( $current_date_time, $sequential_months );
+		$next_date_time     = SE_Calendar::get_instance()->get_next_month_with_events( $current_date_time, $sequential_months );
+
+		if ( ! $sequential_months && ! $month_data['month_has_events'] ) {
 			if ( $next_date_time ) {
 				$current_date   = $next_date_time->format( 'Y-m-01' );
 				$month_data     = SE_Calendar::get_instance()->get_month_days( $current_date );
-				$next_date_time = SE_Calendar::get_instance()->get_next_month_with_events( $next_date_time );
+				$next_date_time = SE_Calendar::get_instance()->get_next_month_with_events( $next_date_time, false );
 			} elseif ( $previous_date_time ) {
 				$current_date       = $previous_date_time->format( 'Y-m-01' );
 				$month_data         = SE_Calendar::get_instance()->get_month_days( $current_date );
-				$previous_date_time = SE_Calendar::get_instance()->get_previous_month_with_events( $previous_date_time );
+				$previous_date_time = SE_Calendar::get_instance()->get_previous_month_with_events( $previous_date_time, false );
 			}
 		}
 

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -189,12 +189,11 @@ class SE_Calendar {
 			$request_date = 'now';
 		}
 
+		$request_attributes = isset( $request_body['attributes'] ) ? $request_body['attributes'] : array();
+		$sequential_months  = isset( $request_attributes['sequentialMonths'] ) ? (bool) $request_attributes['sequentialMonths'] : false;
 		$request_date_time  = $this->create_date_time( $request_date );
-		$previous_date_time = self::get_instance()->get_previous_month_with_events( $request_date_time );
-		$next_date_time     = self::get_instance()->get_next_month_with_events( $request_date_time );
-
-		// Retrieve attributes for template part.
-		$request_attributes = $request_body['attributes'];
+		$previous_date_time = self::get_instance()->get_previous_month_with_events( $request_date_time, $sequential_months );
+		$next_date_time     = self::get_instance()->get_next_month_with_events( $request_date_time, $sequential_months );
 
 		if ( ! $request_attributes ) {
 			$request_attributes = array( 'align' => 'wide' );
@@ -234,11 +233,21 @@ class SE_Calendar {
 	 * Get first previous event with events.
 	 *
 	 * @param DateTime $current_date Current date.
+	 * @param bool     $sequential   When true, returns the previous calendar month regardless of events.
 	 *
 	 * @return DateTime|null
 	 */
-	public function get_previous_month_with_events( $current_date ) {
+	public function get_previous_month_with_events( $current_date, $sequential = false ) {
 		global $wpdb;
+
+		if ( $sequential ) {
+			$previous_date_time = clone $current_date;
+			$previous_date_time->modify( 'first day of this month' );
+			$previous_date_time->modify( '-1 month' );
+			$previous_date_time->setTime( 0, 0, 0 );
+
+			return $previous_date_time;
+		}
 
 		$previous_date_time = clone $current_date;
 		$previous_date_time->modify( 'first day of this month' );
@@ -288,10 +297,19 @@ class SE_Calendar {
 	 * Get first next event with events.
 	 *
 	 * @param DateTime $current_date Current date.
+	 * @param bool     $sequential   When true, returns the next calendar month regardless of events.
 	 *
 	 * @return DateTime|null
 	 */
-	public function get_next_month_with_events( $current_date ) {
+	public function get_next_month_with_events( $current_date, $sequential = false ) {
+		if ( $sequential ) {
+			$next_date_time = clone $current_date;
+			$next_date_time->modify( 'first day of this month' );
+			$next_date_time->modify( '+1 month' );
+			$next_date_time->setTime( 0, 0, 0 );
+
+			return $next_date_time;
+		}
 
 		/**
 		 * Compile a shared set of query args.

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -233,7 +233,7 @@ class SE_Calendar {
 	 * Get first previous event with events.
 	 *
 	 * @param DateTime $current_date Current date.
-	 * @param bool     $sequential   When true, returns the previous calendar month regardless of events.
+	 * @param boolean  $sequential   When true, returns the previous calendar month regardless of events.
 	 *
 	 * @return DateTime|null
 	 */
@@ -297,7 +297,7 @@ class SE_Calendar {
 	 * Get first next event with events.
 	 *
 	 * @param DateTime $current_date Current date.
-	 * @param bool     $sequential   When true, returns the next calendar month regardless of events.
+	 * @param boolean  $sequential   When true, returns the next calendar month regardless of events.
 	 *
 	 * @return DateTime|null
 	 */
@@ -385,9 +385,9 @@ class SE_Calendar {
 	private function get_events_by_date( $date ): array {
 		global $wpdb;
 
-		$day_events       = array();
-		$start_timestamp  = ( clone $date )->setTime( 0, 0, 0 )->getTimestamp();
-		$end_timestamp    = ( clone $date )->setTime( 23, 59, 59 )->getTimestamp();
+		$day_events      = array();
+		$start_timestamp = ( clone $date )->setTime( 0, 0, 0 )->getTimestamp();
+		$end_timestamp   = ( clone $date )->setTime( 23, 59, 59 )->getTimestamp();
 
 		$new_all = SE_Event_Dates::get_event_dates_for_date( $date->format( 'Y-m-d' ), true, false );
 		// If we new dates.

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -367,7 +367,9 @@ class SE_Calendar {
 	private function get_events_by_date( $date ): array {
 		global $wpdb;
 
-		$day_events = array();
+		$day_events       = array();
+		$start_timestamp  = ( clone $date )->setTime( 0, 0, 0 )->getTimestamp();
+		$end_timestamp    = ( clone $date )->setTime( 23, 59, 59 )->getTimestamp();
 
 		$new_all = SE_Event_Dates::get_event_dates_for_date( $date->format( 'Y-m-d' ), true, false );
 		// If we new dates.
@@ -398,7 +400,25 @@ class SE_Calendar {
 			}
 		}
 
-		return $day_events;
+		/**
+		 * Filter the events shown on a single calendar day before rendering.
+		 *
+		 * Useful for deduping event-date rows that map to the same visible event entry.
+		 *
+		 * @param array    $day_events       Events prepared for this calendar day.
+		 * @param DateTime $date             Day being rendered.
+		 * @param int      $start_timestamp  Start of day timestamp in site timezone.
+		 * @param int      $end_timestamp    End of day timestamp in site timezone.
+		 */
+		$day_events = apply_filters(
+			'simple_events_calendar_day_events',
+			$day_events,
+			$date,
+			$start_timestamp,
+			$end_timestamp
+		);
+
+		return is_array( $day_events ) ? $day_events : array();
 	}
 
 

--- a/src/templates/calendar/calendar-container.php
+++ b/src/templates/calendar/calendar-container.php
@@ -29,9 +29,19 @@ $se_editor_screen = defined( 'REST_REQUEST' ) ? REST_REQUEST : false;
 
 	SE_Template_Loader::get_template_part(
 		'calendar/calendar',
-		'main',
+		'skeleton',
 		true,
 		$args
 	);
 	?>
+	<div class="simple-events-calendar-content" data-js="simple-events-calendar-content">
+		<?php
+		SE_Template_Loader::get_template_part(
+			'calendar/calendar',
+			'main',
+			true,
+			$args
+		);
+		?>
+	</div>
 </div>

--- a/src/templates/calendar/calendar-skeleton.php
+++ b/src/templates/calendar/calendar-skeleton.php
@@ -23,14 +23,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</div>
 		</header>
 		<div class="simple-events-calendar-skeleton__header">
-			<?php for ( $i = 0; $i < 7; $i++ ) : ?>
+			<?php for ( $se_i = 0; $se_i < 7; $se_i++ ) : ?>
 				<span></span>
 			<?php endfor; ?>
 		</div>
 		<div class="simple-events-calendar-skeleton__body">
-			<?php for ( $week = 0; $week < 5; $week++ ) : ?>
+			<?php for ( $se_week = 0; $se_week < 5; $se_week++ ) : ?>
 				<div class="simple-events-calendar-skeleton__week">
-					<?php for ( $day = 0; $day < 7; $day++ ) : ?>
+					<?php for ( $se_day = 0; $se_day < 7; $se_day++ ) : ?>
 						<div class="simple-events-calendar-skeleton__day"></div>
 					<?php endfor; ?>
 				</div>

--- a/src/templates/calendar/calendar-skeleton.php
+++ b/src/templates/calendar/calendar-skeleton.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Calendar Skeleton
+ *
+ * Loading skeleton for the calendar. Hidden by default, shown during API requests.
+ *
+ * @var array $args
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<div class="simple-events-calendar-skeleton simple-events-calendar-skeleton--hidden" aria-hidden="true" data-js="simple-events-calendar-skeleton">
+	<div class="simple-events-container">
+		<header class="simple-events-header">
+			<div class="simple-events-calendar-skeleton__top-bar">
+				<span></span>
+				<span></span>
+				<span></span>
+			</div>
+		</header>
+		<div class="simple-events-calendar-skeleton__header">
+			<?php for ( $i = 0; $i < 7; $i++ ) : ?>
+				<span></span>
+			<?php endfor; ?>
+		</div>
+		<div class="simple-events-calendar-skeleton__body">
+			<?php for ( $week = 0; $week < 5; $week++ ) : ?>
+				<div class="simple-events-calendar-skeleton__week">
+					<?php for ( $day = 0; $day < 7; $day++ ) : ?>
+						<div class="simple-events-calendar-skeleton__day"></div>
+					<?php endfor; ?>
+				</div>
+			<?php endfor; ?>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Improve calendar UX during month navigation by adding a loading skeleton while calendar AJAX requests are in flight.
* Fix mobile day selection by using viewport-based mobile detection (instead of CSS display checks that can be overridden by theme styles).
* Add a new calendar block setting, **Show Months in Order** (`sequentialMonths`), to support sequential month-by-month navigation.
* Keep backward compatibility by defaulting `sequentialMonths` to **off** for existing blocks.
* Add `simple_events_calendar_day_events` filter to allow pre-render calendar day event customization (e.g. deduping).
* Bump plugin version to `2.1.2` and add changelog notes in `README.md`.

#### Testing instructions

* Add a Calendar block and verify month navigation shows a loading skeleton during request.
* On mobile width (<768px), tap a day with events and confirm event list opens.
* In block settings:
  * With **Show Months in Order** OFF, navigation skips to months with events.
  * With it ON, navigation moves month-by-month.
* Confirm existing calendar blocks (without explicitly setting `sequentialMonths`) default to OFF behavior.

Mentions #
@gin0115 @tommusrhodus @ecairol - if one of you could review when you get a chance, we have a launch for ThePocketNYC on May 25 that would need these changes, ty!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Show Months in Order" option for sequential calendar month navigation
  * Implemented a skeleton loading state for improved calendar loading experience

* **Bug Fixes**
  * Fixed mobile day-selection logic for better touch interactions

* **Documentation**
  * Added calendar event rendering docs including day-event deduplication
  * Updated changelog for version 2.1.2

* **Chores**
  * Version bumped to 2.1.2

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/simple-events/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->