### PR TITLE
Fix calendar grid alignment when doesn't start on Monday

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Copy the `team51-focal-point` folder to your `mu-plugins` directory.
 
 ## Changelog
 
+### 2.1.3
+
+- **Calendar grid alignment:** fixed month grid date placement when WordPress **Week Starts On** is set to Sunday (or any `start_of_week` other than Monday). Dates and events now appear under the correct weekday column.
+
 ### 2.1.2
 
 - **Calendar loading UX:** added a loading skeleton while calendar month requests are in flight.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.1.1",
+    "version": "2.1.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wpcomsp-simple-events",
-            "version": "2.1.1",
+            "version": "2.1.3",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "ajv": "^8.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     2.1.2
+ * @version     2.1.3
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -14,7 +14,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.5
  * Tested up to:            6.9
- * Version:                 2.1.2
+ * Version:                 2.1.3
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com
@@ -32,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 function_exists( 'get_plugin_data' ) || require_once ABSPATH . 'wp-admin/includes/plugin.php';
 define( 'SE_METADATA', get_plugin_data( __FILE__, false, false ) );
 
-define( 'SE_VERSION', '2.1.2' );
+define( 'SE_VERSION', '2.1.3' );
 define( 'SE_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SE_PLUGIN_DIR', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'SE_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -60,7 +60,7 @@ class SE_Calendar {
 	 * @param string $format The display format for the days of the week.
 	 *
 	 * @return array Days of the week.
-	 **@category Events
+	 * *@category Events
 	 */
 	public function simple_events_get_days_of_week( $format = null ) {
 		global $wp_locale;
@@ -444,8 +444,8 @@ class SE_Calendar {
 	/**
 	 * Get the first calendar cell for the month (weeks align to WordPress start of week).
 	 *
-	 * @param mixed $date          First day of the month to display.
-	 * @param int   $start_of_week `start_of_week` option: 0 = Sunday through 6 = Saturday.
+	 * @param mixed   $date          First day of the month to display.
+	 * @param integer $start_of_week Attribute `start_of_week` option: 0 = Sunday through 6 = Saturday.
 	 *
 	 * @return DateTime First grid day at 00:00:00.
 	 */
@@ -465,8 +465,8 @@ class SE_Calendar {
 	/**
 	 * Get the last day shown in the grid for the month (inclusive), at 23:59:59.
 	 *
-	 * @param mixed $date          Any day in the month (used to find last day of month).
-	 * @param int   $start_of_week `start_of_week` option: 0 = Sunday through 6 = Saturday.
+	 * @param mixed   $date          Any day in the month (used to find last day of month).
+	 * @param integer $start_of_week Attribute `start_of_week` option: 0 = Sunday through 6 = Saturday.
 	 *
 	 * @return DateTime End boundary for the period.
 	 */

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -442,56 +442,48 @@ class SE_Calendar {
 
 
 	/**
-	 * Get the start day based on the given date and start of the week.
+	 * Get the first calendar cell for the month (weeks align to WordPress start of week).
 	 *
-	 * @param mixed   $date          The date for which to calculate the start day.
-	 * @param integer $start_of_week The start of the week (0-6, where 0 is Sunday).
+	 * @param mixed $date          First day of the month to display.
+	 * @param int   $start_of_week `start_of_week` option: 0 = Sunday through 6 = Saturday.
 	 *
-	 * @return DateTime The start day based on the given date and start of the week.
+	 * @return DateTime First grid day at 00:00:00.
 	 */
 	private function get_start_day( $date, $start_of_week ) {
-		$start_date         = clone $date;
-		$start_day_interval = 0;
+		$start_date = clone $date;
+		$start_date->setTime( 0, 0, 0 );
 
-		$start_day_week_position = $date->format( 'w' );
+		$w                = (int) $start_date->format( 'w' );
+		$days_back_to_sow = ( $w - (int) $start_of_week + 7 ) % 7;
 
-		if ( $start_of_week > 0 && 0 === intval( $start_day_week_position ) ) {
-			$start_day_week_position = 7;
-		}
-
-		if ( 0 !== intval( $start_day_week_position ) ) {
-			$start_day_interval = abs( 1 - $start_day_week_position );
-		}
-
-		return $start_date->sub( new DateInterval( 'P' . $start_day_interval . 'D' ) );
+		return 0 === $days_back_to_sow
+			? $start_date
+			: $start_date->sub( new DateInterval( 'P' . $days_back_to_sow . 'D' ) );
 	}
 
 
 	/**
-	 * Get the end day based on the given date and start of the week.
+	 * Get the last day shown in the grid for the month (inclusive), at 23:59:59.
 	 *
-	 * @param Date    $date          The date to calculate the end day from.
-	 * @param integer $start_of_week The start of the `week (0-6, where 0 is Sunday).
+	 * @param mixed $date          Any day in the month (used to find last day of month).
+	 * @param int   $start_of_week `start_of_week` option: 0 = Sunday through 6 = Saturday.
 	 *
-	 * @return DateTime The end day based on the given date and start of the week.
+	 * @return DateTime End boundary for the period.
 	 */
 	private function get_end_day( $date, $start_of_week ) {
-		$end_date          = clone $date;
-		$last_day_interval = 0;
+		$end_date = clone $date;
+		$end_date->modify( 'last day of this month' );
+		$end_date->setTime( 0, 0, 0 );
 
-		$last_day_of_month      = $end_date->modify( 'last day of this month' );
-		$last_day_week_position = $last_day_of_month->format( 'w' );
+		$w             = (int) $end_date->format( 'w' );
+		$offset_in_row = ( $w - (int) $start_of_week + 7 ) % 7;
+		$days_to_add   = 6 - $offset_in_row;
 
-		if ( $start_of_week > 0 && 0 === intval( $last_day_week_position ) ) {
-			$last_day_week_position = 7;
+		if ( $days_to_add > 0 ) {
+			$end_date->add( new DateInterval( 'P' . $days_to_add . 'D' ) );
 		}
-
-		if ( 0 !== intval( $last_day_week_position ) ) {
-			$last_day_interval = 7 - $last_day_week_position;
-		}
-
 		$end_date->setTime( 23, 59, 59 );
 
-		return $end_date->add( new DateInterval( 'P' . $last_day_interval . 'D' ) );
+		return $end_date;
 	}
 }


### PR DESCRIPTION
This issue is live on https://thepocketnyc.com/calendar/grid/

#### Changes proposed in this Pull Request

- Fix `get_start_day()` and `get_end_day()` in `class-se-calendar.php` so the month grid respects WordPress `start_of_week` for all values (0–6), not just Monday.
- Replace Monday-only offset math (`abs(1 - w)` / `7 - w`) with `( w - start_of_week + 7 ) % 7` so dates appear under the correct weekday column.
- Normalize grid boundaries to midnight before calculating offsets.

**Before:** With **Week Starts On → Sunday**, a month whose 1st falls on Monday (e.g. June 2026) showed the 1st under the Sunday column — headers were correct but dates were shifted.

**After:** Grid cells align with weekday headers for both Sunday and Monday week starts.

### Correct: 
<img width="2918" height="2342" alt="Screenshot 2026-06-09 at 12 23 17 PM" src="https://github.com/user-attachments/assets/59df60fe-0c04-4bd9-98af-2f54a6169227" />

### Incorrect:
June 9, 26 is a not a Monday.

<img width="2966" height="2456" alt="Screenshot 2026-06-09 at 12 23 00 PM" src="https://github.com/user-attachments/assets/5fdb9973-d438-465f-a384-e76f5c844cc4" />

#### Testing instructions

1. Add a page with the **Simple Events Calendar** block.
2. Ensure at least one event exists in the month under test.

**Sunday week start (`start_of_week = 0`)**

- Go to **Settings → General → Week Starts On → Sunday**.
- Open the calendar to **June 2026** (1st is a Monday).
- Confirm column headers are Sun–Sat.
- Confirm **June 1** appears under **Monday**, not Sunday.
- Confirm **May 31** (Sunday) appears in the leading cell of the first row.
- Confirm events render on the correct calendar dates.

**Monday week start (`start_of_week = 1`)**

- Set **Week Starts On → Monday**.
- Reload **June 2026**.
- Confirm **June 1** appears under **Monday** (regression check — this case worked before).

**Month navigation**

- Use prev/next month controls (initial render and AJAX).
- Confirm leading/trailing days from adjacent months still align correctly.
- Confirm events stay on the correct dates after navigation.

Mentions #
@gin0115 @tommusrhodus 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar grid alignment so dates and events appear under the correct weekday when the week start is set to Sunday or any day other than Monday.

* **Chores**
  * Version bumped to 2.1.3.

* **Documentation**
  * Changelog updated to reflect the 2.1.3 fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->