### PR TITLE
Fix draft/pending events leaking into calendar views (gh78)

### DIFF
--- a/src/classes/class-se-blocks.php
+++ b/src/classes/class-se-blocks.php
@@ -587,10 +587,10 @@ class SE_Blocks {
 			if ( ! se_event_treat_each_date_as_own_event() ) {
 				$events_query_args['unique_parents'] = true;
 				$events_query_args['feed_order']     = $feed_order;
-
-				// Add filter for unique parents WHERE clause
-				add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 			}
+
+			// Always ensure the parent event is published (also enforces unique parents above when set).
+			add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 
 			$show_year_dividers = ! empty( $attributes['showYearDividers'] );
 
@@ -631,8 +631,8 @@ class SE_Blocks {
 			}
 
 			// Clean up filters
+			remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 			if ( ! se_event_treat_each_date_as_own_event() ) {
-				remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 				remove_filter( 'the_posts', array( 'SE_Event_Query_Utils', 'modify_event_posts' ), 10 );
 			}
 

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -280,7 +280,10 @@ class SE_Calendar {
 			'limit'      => 1,
 		);
 
+		// Only consider dates whose parent event is published.
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
 		$query = new WP_Query( $args );
+		remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 
 		if ( $query->have_posts() ) {
 			$previous_event = $query->posts[0];
@@ -354,6 +357,9 @@ class SE_Calendar {
 
 		$next_event = null;
 
+		// Only consider dates whose parent event is published.
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
+
 		// At first try to get the next event with the start date.
 		$query = new WP_Query( $query_args( 'se_event_date_start' ) );
 		if ( $query->have_posts() ) {
@@ -365,6 +371,8 @@ class SE_Calendar {
 				$next_event = $query->posts[0];
 			}
 		}
+
+		remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 
 		if ( empty( $next_event ) ) {
 			return null;

--- a/src/classes/class-se-event-dates.php
+++ b/src/classes/class-se-event-dates.php
@@ -278,6 +278,9 @@ class SE_Event_Dates {
 			$start_date_time->setTime( 23, 59, 59 )->getTimestamp(),
 		);
 
+		// Only return dates whose parent event is published (same guard as archive/feed).
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
+
 		// Query the event dates.
 		$query = new WP_Query(
 			array(
@@ -320,6 +323,8 @@ class SE_Event_Dates {
 				'post_status'    => 'publish',
 			)
 		);
+
+		remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 
 		$mapped = self::map_events_dates_to_event_dates( $query->posts );
 

--- a/tests/phpunit/Blocks/UpcomingEventsDraftTest.php
+++ b/tests/phpunit/Blocks/UpcomingEventsDraftTest.php
@@ -49,7 +49,7 @@ class UpcomingEventsDraftTest extends WP_UnitTestCase {
 	 * @param string $parent_status Parent se-event post_status.
 	 * @param string $start_day     Date in 'Y-m-d' form for the event date.
 	 *
-	 * @return int The parent event ID.
+	 * @return integer The parent event ID.
 	 */
 	private function make_event( $parent_status, $start_day ) {
 		$event_id = $this->factory->post->create(

--- a/tests/phpunit/Blocks/UpcomingEventsDraftTest.php
+++ b/tests/phpunit/Blocks/UpcomingEventsDraftTest.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Tests that the Upcoming Events block excludes events whose parent is not published.
+ *
+ * The block queries se-event-date posts. When "treat each date as own event" is enabled
+ * it skips the unique-parents path and previously applied no parent-published guard, so a
+ * draft event's date still rendered. This covers that branch end-to-end via the rendered
+ * markup (content-archive.php emits <li id="post-{parent_id}">).
+ *
+ * @package Simple_Events
+ */
+class UpcomingEventsDraftTest extends WP_UnitTestCase {
+
+	/**
+	 * Stash the original se_options so the treat-each-date toggle can be restored.
+	 *
+	 * @var mixed
+	 */
+	private $original_options;
+
+	/**
+	 * Enable "treat each date as own event" (the unguarded branch under test).
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->original_options = get_option( 'se_options' );
+		update_option( 'se_options', array( 'treat_each_date_as_own_event' => 'on' ) );
+	}
+
+	/**
+	 * Restore options.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		if ( false === $this->original_options ) {
+			delete_option( 'se_options' );
+		} else {
+			update_option( 'se_options', $this->original_options );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create an event of a given status with a single upcoming date.
+	 *
+	 * @param string $parent_status Parent se-event post_status.
+	 * @param string $start_day     Date in 'Y-m-d' form for the event date.
+	 *
+	 * @return int The parent event ID.
+	 */
+	private function make_event( $parent_status, $start_day ) {
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'se-event',
+				'post_status' => $parent_status,
+			)
+		);
+
+		$tz    = wp_timezone();
+		$start = DateTime::createFromFormat( 'Y-m-d H:i:s', $start_day . ' 10:00:00', $tz )->getTimestamp();
+		$end   = DateTime::createFromFormat( 'Y-m-d H:i:s', $start_day . ' 11:00:00', $tz )->getTimestamp();
+
+		$date = se_event_create_event_date(
+			$event_id,
+			array(
+				'start_date' => $start,
+				'end_date'   => $end,
+				'all_day'    => false,
+			)
+		);
+		$this->assertNotNull( $date );
+
+		return $event_id;
+	}
+
+	/**
+	 * Render the Upcoming Events block (future feed).
+	 *
+	 * @return string
+	 */
+	private function render() {
+		return SE_Blocks::upcoming_events_render(
+			array(
+				'count'            => 10,
+				'feedType'         => 'upcoming',
+				'feedOrder'        => 'ASC',
+				'showYearDividers' => false,
+				'layout'           => 'list',
+				'columns'          => 1,
+				'align'            => '',
+				'className'        => '',
+			),
+			''
+		);
+	}
+
+	/**
+	 * A published event's date renders; a draft event's date does not.
+	 *
+	 * @return void
+	 */
+	public function test_block_excludes_draft_parent_events() {
+		$published = $this->make_event( 'publish', '2030-08-10' );
+		$draft     = $this->make_event( 'draft', '2030-08-11' );
+
+		$html = $this->render();
+
+		$this->assertStringContainsString( 'post-' . $published, $html, 'Published event should render in the upcoming events block.' );
+		$this->assertStringNotContainsString( 'post-' . $draft, $html, 'Draft event should not render in the upcoming events block.' );
+	}
+}

--- a/tests/phpunit/Calendar/CalendarMonthNavDraftTest.php
+++ b/tests/phpunit/Calendar/CalendarMonthNavDraftTest.php
@@ -2,10 +2,10 @@
 /**
  * Tests that calendar month navigation ignores events whose parent is not published.
  *
- * get_previous_month_with_events() / get_next_month_with_events() decide which month
- * the prev/next arrows jump to by querying se-event-date posts. Those date posts are
- * always 'publish', so without a parent-published guard a draft event still drives the
- * navigation.
+ * Both get_previous_month_with_events() and get_next_month_with_events() decide which
+ * month the prev/next arrows jump to by querying se-event-date posts. Those date posts
+ * are always 'publish', so without a parent-published guard a draft event still drives
+ * the navigation.
  *
  * @package Simple_Events
  */
@@ -17,7 +17,7 @@ class CalendarMonthNavDraftTest extends WP_UnitTestCase {
 	 * @param string $parent_status Parent se-event post_status.
 	 * @param string $start_day     Date in 'Y-m-d' form for the event date.
 	 *
-	 * @return int The parent event ID.
+	 * @return integer The parent event ID.
 	 */
 	private function make_event( $parent_status, $start_day ) {
 		$event_id = $this->factory->post->create(

--- a/tests/phpunit/Calendar/CalendarMonthNavDraftTest.php
+++ b/tests/phpunit/Calendar/CalendarMonthNavDraftTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests that calendar month navigation ignores events whose parent is not published.
+ *
+ * get_previous_month_with_events() / get_next_month_with_events() decide which month
+ * the prev/next arrows jump to by querying se-event-date posts. Those date posts are
+ * always 'publish', so without a parent-published guard a draft event still drives the
+ * navigation.
+ *
+ * @package Simple_Events
+ */
+class CalendarMonthNavDraftTest extends WP_UnitTestCase {
+
+	/**
+	 * Create an event of a given status with a single date on $start_day.
+	 *
+	 * @param string $parent_status Parent se-event post_status.
+	 * @param string $start_day     Date in 'Y-m-d' form for the event date.
+	 *
+	 * @return int The parent event ID.
+	 */
+	private function make_event( $parent_status, $start_day ) {
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'se-event',
+				'post_status' => $parent_status,
+			)
+		);
+
+		$tz    = wp_timezone();
+		$start = DateTime::createFromFormat( 'Y-m-d H:i:s', $start_day . ' 10:00:00', $tz )->getTimestamp();
+		$end   = DateTime::createFromFormat( 'Y-m-d H:i:s', $start_day . ' 11:00:00', $tz )->getTimestamp();
+
+		$date = se_event_create_event_date(
+			$event_id,
+			array(
+				'start_date' => $start,
+				'end_date'   => $end,
+				'all_day'    => false,
+			)
+		);
+		$this->assertNotNull( $date );
+
+		return $event_id;
+	}
+
+	/**
+	 * The reference "current" month for navigation (June 2030).
+	 *
+	 * @return DateTime
+	 */
+	private function june_2030() {
+		return new DateTime( '2030-06-15', wp_timezone() );
+	}
+
+	/**
+	 * Happy path: a published event in an earlier month is found by prev-nav.
+	 *
+	 * @return void
+	 */
+	public function test_prev_month_returns_published_earlier_event() {
+		$this->make_event( 'publish', '2030-04-10' );
+
+		$result = SE_Calendar::get_instance()->get_previous_month_with_events( $this->june_2030() );
+
+		$this->assertInstanceOf( DateTime::class, $result );
+		$this->assertSame( '2030-04', $result->format( 'Y-m' ) );
+	}
+
+	/**
+	 * Sad path: a draft event in an earlier month must not drive prev-nav.
+	 *
+	 * @return void
+	 */
+	public function test_prev_month_skips_draft_earlier_event() {
+		$this->make_event( 'draft', '2030-04-10' );
+
+		$result = SE_Calendar::get_instance()->get_previous_month_with_events( $this->june_2030() );
+
+		$this->assertNull( $result, 'Draft event in an earlier month must not drive prev-month navigation.' );
+	}
+
+	/**
+	 * Happy path: a published event in a future month is found by next-nav.
+	 *
+	 * @return void
+	 */
+	public function test_next_month_returns_published_future_event() {
+		$this->make_event( 'publish', '2030-08-10' );
+
+		$result = SE_Calendar::get_instance()->get_next_month_with_events( $this->june_2030() );
+
+		$this->assertInstanceOf( DateTime::class, $result );
+		$this->assertSame( '2030-08', $result->format( 'Y-m' ) );
+	}
+
+	/**
+	 * Sad path: a draft event in a future month must not drive next-nav.
+	 *
+	 * @return void
+	 */
+	public function test_next_month_skips_draft_future_event() {
+		$this->make_event( 'draft', '2030-08-10' );
+
+		$result = SE_Calendar::get_instance()->get_next_month_with_events( $this->june_2030() );
+
+		$this->assertNull( $result, 'Draft event in a future month must not drive next-month navigation.' );
+	}
+
+	/**
+	 * Mixed: a nearer draft event must be skipped in favour of a later published one.
+	 *
+	 * @return void
+	 */
+	public function test_next_month_skips_nearer_draft_for_later_published() {
+		$this->make_event( 'draft', '2030-07-10' );   // nearer, but draft.
+		$this->make_event( 'publish', '2030-09-10' ); // further, published.
+
+		$result = SE_Calendar::get_instance()->get_next_month_with_events( $this->june_2030() );
+
+		$this->assertInstanceOf( DateTime::class, $result );
+		$this->assertSame( '2030-09', $result->format( 'Y-m' ), 'Next-nav should skip the nearer draft and land on the published event.' );
+	}
+}

--- a/tests/phpunit/EventDates/EventDatesParentStatusTest.php
+++ b/tests/phpunit/EventDates/EventDatesParentStatusTest.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests that calendar event-date queries respect the parent event's publish status.
+ *
+ * Regression coverage: event-date posts are always created as 'publish', and the
+ * calendar query (SE_Event_Dates::find_event_dates) filters only on the date post's
+ * own status. Without a parent-published guard, a date whose parent se-event is in
+ * draft/pending status still leaked into the calendar. find_event_dates() now applies
+ * SE_Event_Query_Utils::filter_event_dates_where, matching the archive/feed behaviour.
+ *
+ * @package Simple_Events
+ */
+class EventDatesParentStatusTest extends WP_UnitTestCase {
+
+	/**
+	 * The calendar day used across these tests.
+	 *
+	 * @var string
+	 */
+	private $day = '2030-06-15';
+
+	/**
+	 * Create an event of a given status with a single date on $this->day.
+	 *
+	 * The date itself is always created as 'publish' (mirroring production
+	 * behaviour) so the only thing under test is the parent event's status.
+	 *
+	 * @param string $parent_status Parent se-event post_status (publish, draft, pending...).
+	 *
+	 * @return array{event_id:int, date_id:int} The parent and child IDs.
+	 */
+	private function create_event_with_date( $parent_status ) {
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'se-event',
+				'post_status' => $parent_status,
+			)
+		);
+
+		$tz    = wp_timezone();
+		$start = DateTime::createFromFormat( 'Y-m-d H:i:s', $this->day . ' 10:00:00', $tz )->getTimestamp();
+		$end   = DateTime::createFromFormat( 'Y-m-d H:i:s', $this->day . ' 11:00:00', $tz )->getTimestamp();
+
+		$date = se_event_create_event_date(
+			$event_id,
+			array(
+				'start_date' => $start,
+				'end_date'   => $end,
+				'all_day'    => false,
+			)
+		);
+
+		$this->assertNotNull( $date, 'Fixture event-date should have been created.' );
+		// The child date is published regardless of the parent's status.
+		$this->assertSame( 'publish', get_post_status( $date->ID ) );
+
+		return array(
+			'event_id' => $event_id,
+			'date_id'  => $date->ID,
+		);
+	}
+
+	/**
+	 * Collect the parent event IDs returned for the test day.
+	 *
+	 * @return int[]
+	 */
+	private function event_ids_for_day() {
+		$dates = SE_Event_Dates::get_event_dates_for_date( $this->day );
+		return wp_list_pluck( $dates, 'event_id' );
+	}
+
+	/**
+	 * Happy path: a date whose parent event is published is returned for the calendar.
+	 *
+	 * @return void
+	 */
+	public function test_published_parent_event_date_is_returned() {
+		$ids = $this->create_event_with_date( 'publish' );
+
+		$this->assertContains(
+			$ids['event_id'],
+			$this->event_ids_for_day(),
+			'A published event\'s date should appear in the calendar.'
+		);
+	}
+
+	/**
+	 * Sad path: a date whose parent event is in draft status must NOT be returned.
+	 *
+	 * @return void
+	 */
+	public function test_draft_parent_event_date_is_excluded() {
+		$ids = $this->create_event_with_date( 'draft' );
+
+		$this->assertNotContains(
+			$ids['event_id'],
+			$this->event_ids_for_day(),
+			'A draft event\'s date should not appear in the calendar.'
+		);
+	}
+
+	/**
+	 * Sad path: a date whose parent event is pending must NOT be returned either.
+	 *
+	 * @return void
+	 */
+	public function test_pending_parent_event_date_is_excluded() {
+		$ids = $this->create_event_with_date( 'pending' );
+
+		$this->assertNotContains(
+			$ids['event_id'],
+			$this->event_ids_for_day(),
+			'A pending event\'s date should not appear in the calendar.'
+		);
+	}
+
+	/**
+	 * Mixed: on a day with both a published and a draft event, only the published
+	 * one is returned. Guards against the filter being too broad or too narrow.
+	 *
+	 * @return void
+	 */
+	public function test_only_published_parents_returned_when_mixed() {
+		$published = $this->create_event_with_date( 'publish' );
+		$draft     = $this->create_event_with_date( 'draft' );
+
+		$returned = $this->event_ids_for_day();
+
+		$this->assertContains( $published['event_id'], $returned, 'Published event should be present.' );
+		$this->assertNotContains( $draft['event_id'], $returned, 'Draft event should be filtered out.' );
+	}
+
+	/**
+	 * End-to-end through the calendar grid: the rendered month must not list a
+	 * draft event's date in its day cell, but must list the published one.
+	 *
+	 * @return void
+	 */
+	public function test_calendar_grid_excludes_draft_parent_events() {
+		$published = $this->create_event_with_date( 'publish' );
+		$draft     = $this->create_event_with_date( 'draft' );
+
+		$days = SE_Calendar::get_instance()->get_month_days( '2030-06-01' )['days'];
+
+		$event_ids_in_cell = array();
+		foreach ( $days as $day ) {
+			if ( $this->day === $day['date']->format( 'Y-m-d' ) ) {
+				foreach ( $day['events'] as $event ) {
+					$event_ids_in_cell[] = $event->event_id;
+				}
+			}
+		}
+
+		$this->assertContains( $published['event_id'], $event_ids_in_cell, 'Published event should render in the calendar cell.' );
+		$this->assertNotContains( $draft['event_id'], $event_ids_in_cell, 'Draft event should not render in the calendar cell.' );
+	}
+}


### PR DESCRIPTION
## Summary

Events whose parent `se-event` is in `draft` or `pending` status still appeared on the public front end in three places:

1. The **calendar grid** day cells.
2. The **previous/next month navigation** (arrows jumped to / were driven by months whose only event was unpublished).
3. The **Upcoming Events block** when "treat each date as own event" is enabled.

Archive/feed views and the Query Loop variation were already unaffected.

## Cause

Each event stores its dates as child `se-event-date` posts, which are **always created with `post_status => 'publish'`** (`se_event_create_event_date()`), with no status sync. So moving a parent to draft/pending leaves its date posts published. The calendar-facing queries filtered only on the **date post's own** status, never the **parent event's** — so the dates leaked through.

A guard already exists, `SE_Event_Query_Utils::filter_event_dates_where()` (used by archive/feed/Query-Loop), which appends `AND post_parent IN (SELECT ID ... WHERE post_type = 'se-event' AND post_status = 'publish')`. It simply was not wired into the three sites above.

## Changes

Apply that existing guard to the three unguarded front-end query sites:

- `SE_Event_Dates::find_event_dates()` — calendar grid
- `SE_Calendar::get_previous_month_with_events()` / `get_next_month_with_events()` — month nav
- `SE_Blocks::upcoming_events_render()` — made the guard unconditional (was only applied on the non-"treat each date as own event" branch)

Queries that read an event's **own** dates (editor, REST sync, trash/untrash, cleanup) are intentionally left unguarded — they must see all statuses.

## Tests

Added PHPUnit coverage for each path (happy + sad), proven red against the unfixed code and green after the fix:

- `EventDatesParentStatusTest` — calendar grid (5)
- `CalendarMonthNavDraftTest` — prev/next month nav (5)
- `UpcomingEventsDraftTest` — Upcoming Events block (1)

Full suite green: 25 tests, 76 assertions.

## Steps to reproduce (before fix)

1. Create an `se-event`, add dates, and publish it (creates the child date posts).
2. Move the event back to **Draft** (or **Pending Review**).
3. View the front-end calendar for that month — the event still shows; the prev/next arrows still navigate by it; with "treat each date as own event" on, it also shows in the Upcoming Events block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Upcoming Events block now excludes events whose parent is not published (e.g., draft), even when each date is treated as its own event.
* Calendar month navigation (previous/next) now skips months that only contain events whose parent is not published.
* Event-date retrieval for the calendar now respects the parent event’s publish status.

## Tests
* Added PHPUnit coverage for upcoming-events exclusion, calendar navigation skipping draft parents, and calendar/event-date filtering based on parent status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->