### PR TITLE
Calendar now does a whole time period query, not daily and iterate ov…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:api.github.com)",
-      "Read(//media/glynn/2024/devilbox_public/keysjazzbistro/htdocs/wp-content/plugins/simple-events/src/classes/**)"
-    ]
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
     "allow": [
-      "WebFetch(domain:api.github.com)"
+      "WebFetch(domain:api.github.com)",
+      "Read(//media/glynn/2024/devilbox_public/keysjazzbistro/htdocs/wp-content/plugins/simple-events/src/classes/**)"
     ]
   }
 }

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -404,8 +404,6 @@ class SE_Calendar {
 	 * @return array The enriched events for the day.
 	 */
 	private function get_events_by_date( $date, array $events ): array {
-		global $wpdb;
-
 		$day_events      = array();
 		$start_timestamp = ( clone $date )->setTime( 0, 0, 0 )->getTimestamp();
 		$end_timestamp   = ( clone $date )->setTime( 23, 59, 59 )->getTimestamp();

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -260,11 +260,13 @@ class SE_Calendar {
 		$previous_date_time->settime( 0, 0, 0 );
 
 		$args = array(
-			'post_type'   => SE_Event_Post_Type::$event_date_post_type,
-			'post_status' => 'publish',
-			'meta_query'  => array(
-				'relation' => 'AND',
-				array(
+			'post_type'      => SE_Event_Post_Type::$event_date_post_type,
+			'post_status'    => 'publish',
+			'posts_per_page' => 1,
+			'no_found_rows'  => true,
+			'meta_query'     => array(
+				'relation'     => 'AND',
+				'start_clause' => array(
 					'key'     => 'se_event_date_start',
 					'value'   => $previous_date_time->getTimestamp(),
 					'compare' => '<',
@@ -282,9 +284,7 @@ class SE_Calendar {
 					),
 				),
 			),
-			'orderby'     => 'meta_value',
-			'order'       => 'DESC',
-			'limit'       => 1,
+			'orderby'        => array( 'start_clause' => 'DESC' ),
 		);
 
 		// Only consider dates whose parent event is published (same guard the grid uses).
@@ -338,11 +338,13 @@ class SE_Calendar {
 			$next_date_time->settime( 23, 59, 59 );
 
 			return array(
-				'post_type'   => SE_Event_Post_Type::$event_date_post_type,
-				'post_status' => 'publish',
-				'meta_query'  => array(
-					'relation' => 'AND',
-					array(
+				'post_type'      => SE_Event_Post_Type::$event_date_post_type,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'no_found_rows'  => true,
+				'meta_query'     => array(
+					'relation'    => 'AND',
+					'date_clause' => array(
 						'key'     => $meta_key,
 						'value'   => $next_date_time->getTimestamp(),
 						'compare' => '>',
@@ -360,9 +362,7 @@ class SE_Calendar {
 						),
 					),
 				),
-				'orderby'     => 'meta_value',
-				'order'       => 'ASC',
-				'limit'       => 1,
+				'orderby'        => array( 'date_clause' => 'ASC' ),
 			);
 		};
 

--- a/src/classes/class-se-calendar.php
+++ b/src/classes/class-se-calendar.php
@@ -143,13 +143,19 @@ class SE_Calendar {
 		$start_day = $this->get_start_day( $current_date, $start_of_week );
 		$end_day   = $this->get_end_day( $current_date, $start_of_week );
 
+		// Fetch the whole visible grid in a single query, bucketed per day,
+		// instead of one query per calendar cell (the old N+1 hot spot).
+		$range_events = $this->bucket_event_dates_by_day(
+			SE_Event_Query_Utils::get_event_dates_for_range( $start_day->getTimestamp(), $end_day->getTimestamp() )
+		);
+
 		$period = new DatePeriod( $start_day, new DateInterval( 'P1D' ), $end_day );
 
 		foreach ( $period as $day ) {
 			$day->setTime( 0, 0, 0 );
 			$day_formatted = $day->format( 'Y-m-d' );
 			$day_month     = $day->format( 'n' );
-			$events        = $this->get_events_by_date( $day );
+			$events        = $this->get_events_by_date( $day, $range_events[ $day_formatted ] ?? array() );
 
 			if ( ! $data['month_has_events'] && ! empty( $events ) && $day_month === $current_month ) {
 				$data['month_has_events'] = true;
@@ -254,8 +260,9 @@ class SE_Calendar {
 		$previous_date_time->settime( 0, 0, 0 );
 
 		$args = array(
-			'post_type'  => SE_Event_Post_Type::$event_date_post_type,
-			'meta_query' => array(
+			'post_type'   => SE_Event_Post_Type::$event_date_post_type,
+			'post_status' => 'publish',
+			'meta_query'  => array(
 				'relation' => 'AND',
 				array(
 					'key'     => 'se_event_date_start',
@@ -275,12 +282,18 @@ class SE_Calendar {
 					),
 				),
 			),
-			'orderby'    => 'meta_value',
-			'order'      => 'DESC',
-			'limit'      => 1,
+			'orderby'     => 'meta_value',
+			'order'       => 'DESC',
+			'limit'       => 1,
 		);
 
-		$query = new WP_Query( $args );
+		// Only consider dates whose parent event is published (same guard the grid uses).
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
+		try {
+			$query = new WP_Query( $args );
+		} finally {
+			remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
+		}
 
 		if ( $query->have_posts() ) {
 			$previous_event = $query->posts[0];
@@ -325,8 +338,9 @@ class SE_Calendar {
 			$next_date_time->settime( 23, 59, 59 );
 
 			return array(
-				'post_type'  => SE_Event_Post_Type::$event_date_post_type,
-				'meta_query' => array(
+				'post_type'   => SE_Event_Post_Type::$event_date_post_type,
+				'post_status' => 'publish',
+				'meta_query'  => array(
 					'relation' => 'AND',
 					array(
 						'key'     => $meta_key,
@@ -346,24 +360,30 @@ class SE_Calendar {
 						),
 					),
 				),
-				'orderby'    => 'meta_value',
-				'order'      => 'ASC',
-				'limit'      => 1,
+				'orderby'     => 'meta_value',
+				'order'       => 'ASC',
+				'limit'       => 1,
 			);
 		};
 
 		$next_event = null;
 
-		// At first try to get the next event with the start date.
-		$query = new WP_Query( $query_args( 'se_event_date_start' ) );
-		if ( $query->have_posts() ) {
-			$next_event = $query->posts[0];
-		} else {
-			// If we don't have a next event with the start date, try with the end date.
-			$query = new WP_Query( $query_args( 'se_event_date_end' ) );
+		// Only consider dates whose parent event is published (same guard the grid uses).
+		add_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10, 2 );
+		try {
+			// At first try to get the next event with the start date.
+			$query = new WP_Query( $query_args( 'se_event_date_start' ) );
 			if ( $query->have_posts() ) {
 				$next_event = $query->posts[0];
+			} else {
+				// If we don't have a next event with the start date, try with the end date.
+				$query = new WP_Query( $query_args( 'se_event_date_end' ) );
+				if ( $query->have_posts() ) {
+					$next_event = $query->posts[0];
+				}
 			}
+		} finally {
+			remove_filter( 'posts_where', array( 'SE_Event_Query_Utils', 'filter_event_dates_where' ), 10 );
 		}
 
 		if ( empty( $next_event ) ) {
@@ -376,23 +396,29 @@ class SE_Calendar {
 
 
 	/**
-	 * Retrieves events from the database for a given date.
+	 * Build the display events for a single calendar day from its bucketed dates.
 	 *
-	 * @param mixed $date The date to retrieve events for.
+	 * @param mixed $date   The day being rendered.
+	 * @param array $events Pre-bucketed event dates for this day (from get_month_days()).
 	 *
-	 * @return array The array of events for the given date.
+	 * @return array The enriched events for the day.
 	 */
-	private function get_events_by_date( $date ): array {
+	private function get_events_by_date( $date, array $events ): array {
 		global $wpdb;
 
 		$day_events      = array();
 		$start_timestamp = ( clone $date )->setTime( 0, 0, 0 )->getTimestamp();
 		$end_timestamp   = ( clone $date )->setTime( 23, 59, 59 )->getTimestamp();
 
-		$new_all = SE_Event_Dates::get_event_dates_for_date( $date->format( 'Y-m-d' ), true, false );
-		// If we new dates.
-		if ( ! empty( $new_all ) ) {
-			foreach ( $new_all as $event ) {
+		// If we have dates.
+		if ( ! empty( $events ) ) {
+			foreach ( $events as $event ) {
+
+				// The calendar hides dates flagged hide_from_calendar; feed hiding
+				// is the feed's concern, so a feed-only-hidden date still shows here.
+				if ( ! empty( $event['event_hide_from_calendar'] ) ) {
+					continue;
+				}
 
 				// Get the parent post.
 				$parent_post = get_post( $event['event_id'] );
@@ -440,6 +466,37 @@ class SE_Calendar {
 	}
 
 
+
+	/**
+	 * Group event dates by the calendar day they render on ('Y-m-d' => dates).
+	 *
+	 * All-day dates land on their start day; timed dates only if they end the
+	 * same day (a timed date crossing midnight lands on no day).
+	 *
+	 * @param array<int, array{event_id: int, event_date_id: int, event_start_date: string, event_end_date: string, event_all_day: bool, event_hide_from_calendar: bool, event_hide_from_feed: bool}> $event_dates Mapped dates from SE_Event_Query_Utils::get_event_dates_for_range().
+	 *
+	 * @return array<string, array<int, array>> Map of 'Y-m-d' day => event dates.
+	 */
+	private function bucket_event_dates_by_day( array $event_dates ): array {
+		$buckets = array();
+
+		foreach ( $event_dates as $event_date ) {
+			$start_day = se_create_date_time_from_timestamp( $event_date['event_start_date'] )->format( 'Y-m-d' );
+
+			if ( $event_date['event_all_day'] ) {
+				$buckets[ $start_day ][] = $event_date;
+				continue;
+			}
+
+			// Timed dates only render on their start day, and only if they end it.
+			$end_day = se_create_date_time_from_timestamp( $event_date['event_end_date'] )->format( 'Y-m-d' );
+			if ( $end_day === $start_day ) {
+				$buckets[ $start_day ][] = $event_date;
+			}
+		}
+
+		return $buckets;
+	}
 
 	/**
 	 * Get the first calendar cell for the month (weeks align to WordPress start of week).

--- a/src/classes/class-se-event-dates.php
+++ b/src/classes/class-se-event-dates.php
@@ -260,72 +260,25 @@ class SE_Event_Dates {
 	}
 
 	/**
-	 * Fiind event dates.
+	 * Find event dates.
+	 *
+	 * @deprecated 2.2.0 Use SE_Event_Query_Utils::get_event_dates_for_range() instead.
 	 *
 	 * @param string  $start_date         The start date as a timestamp.
 	 * @param string  $end_date           The end date as a timestamp.
-	 * @param boolean $hide_from_calendar Whether the event is hidden from the calendar.
-	 * @param boolean $hide_from_feed     Whether the event is hidden from the feed.
+	 * @param boolean $hide_from_calendar Legacy, no longer used.
+	 * @param boolean $hide_from_feed     Legacy, no longer used.
 	 *
 	 * @return array
 	 */
-	public static function find_event_dates( $start_date, $end_date, $hide_from_calendar, $hide_from_feed ): array {
-		// Create the timestamp for the start and end of the $start_date.
-		$start_date_time = se_create_date_time_from_timestamp( $start_date )->setTimezone( wp_timezone() );
+	public static function find_event_dates( $start_date, $end_date, $hide_from_calendar, $hide_from_feed ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		_deprecated_function( __METHOD__, '2.2.0', 'SE_Event_Query_Utils::get_event_dates_for_range()' );
 
-		$start_date_range = array(
-			$start_date_time->setTime( 0, 0, 0 )->getTimestamp(),
-			$start_date_time->setTime( 23, 59, 59 )->getTimestamp(),
-		);
-
-		// Query the event dates.
-		$query = new WP_Query(
-			array(
-				'post_type'      => SE_Event_Post_Type::$event_date_post_type,
-				'meta_query'     => array(
-					'relation' => 'OR',
-					// Exact match for all conditions
-					array(
-						'relation' => 'AND',
-						array(
-							'key'     => 'se_event_date_start',
-							'value'   => $start_date,
-							'compare' => '>=',
-						),
-						array(
-							'key'     => 'se_event_date_end',
-							'value'   => $end_date,
-							'compare' => '<=',
-						),
-					),
-					// All day events with matching start date
-					array(
-						'relation' => 'AND',
-						array(
-							'key'     => 'se_event_date_start',
-							'value'   => $start_date_range,
-							'compare' => 'BETWEEN',
-						),
-						array(
-							'key'     => 'se_event_all_day',
-							'value'   => '1',
-							'compare' => '=',
-						),
-					),
-				),
-				'posts_per_page' => -1,
-				'orderby'        => 'meta_value',
-				'meta_key'       => 'se_event_date_start',
-				'order'          => 'ASC',
-				'post_status'    => 'publish',
-			)
-		);
-
-		$mapped = self::map_events_dates_to_event_dates( $query->posts );
+		$results = SE_Event_Query_Utils::get_event_dates_for_range( (int) $start_date, (int) $end_date );
 
 		// Remove the event dates that are hidden from the calendar or feed.
 		return array_filter(
-			$mapped,
+			$results,
 			function ( $event_date ) use ( $hide_from_calendar, $hide_from_feed ) {
 				return ! $event_date['event_hide_from_calendar'] && ! $event_date['event_hide_from_feed'];
 			}
@@ -335,69 +288,47 @@ class SE_Event_Dates {
 	/**
 	 * Get the events dates for a given date.
 	 *
+	 * @deprecated 2.2.0 Use SE_Event_Query_Utils::get_event_dates_for_range() instead (Returns all results, doesnt exclude hidden events).
+	 *
 	 * @param string  $date               The date to get the events for.
-	 * @param boolean $hide_from_calendar Whether the event is hidden from the calendar.
-	 * @param boolean $hide_from_feed     Whether the event is hidden from the feed.
+	 * @param boolean $hide_from_calendar Legacy flag, no longer used in replacement function.
+	 * @param boolean $hide_from_feed     Legacy flag, no longer used in replacement function.
 	 *
 	 * @return array
 	 */
-	public static function get_event_dates_for_date( $date, $hide_from_calendar = false, $hide_from_feed = false ): array {
-		// Create date explicitly in site timezone
+	public static function get_event_dates_for_date( $date, $hide_from_calendar = false, $hide_from_feed = false ): array { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter
+		_deprecated_function( __METHOD__, '2.2.0', 'SE_Event_Query_Utils::get_event_dates_for_range()' );
+
 		$date_time = DateTime::createFromFormat( 'Y-m-d H:i:s', $date . ' 00:00:00', wp_timezone() );
+		if ( false === $date_time ) {
+			return array();
+		}
+		$results = SE_Event_Query_Utils::get_event_dates_for_range(
+			$date_time->setTime( 0, 0, 0 )->getTimestamp(),
+			$date_time->setTime( 23, 59, 59 )->getTimestamp()
+		);
 
-		// Set the time to the start of the day.
-		$date_time->setTime( 0, 0, 0 );
-		// set as a timestamp.
-		$start_date = $date_time->getTimestamp();
-
-		// Get the end of the day for the date.
-		$date_time->setTime( 23, 59, 59 );
-		$end_date = $date_time->getTimestamp();
-
-		// Get the events dates.
-		$events_dates = self::find_event_dates( $start_date, $end_date, $hide_from_calendar, $hide_from_feed );
-
-		// Return the events dates.
-		return $events_dates;
+		// Remove the event dates that are hidden from the calendar or feed.
+		return array_filter(
+			$results,
+			function ( $event_date ) use ( $hide_from_calendar, $hide_from_feed ) {
+				return ! $event_date['event_hide_from_calendar'] && ! $event_date['event_hide_from_feed'];
+			}
+		);
 	}
 
 	/**
 	 * Map the events dates to the event dates.
+	 *
+	 * @deprecated 2.2.0 Use SE_Event_Query_Utils::map_events_dates_to_event_dates() instead.
 	 *
 	 * @param array $events_dates The events dates.
 	 *
 	 * @return array{event_id: int, event_date_id: int, event_start_date: string, event_end_date: string, event_all_day: bool, event_hide_from_calendar: bool, event_hide_from_feed: bool}
 	 */
 	public static function map_events_dates_to_event_dates( $events_dates ): array {
-		$compiled_events = array();
-		foreach ( $events_dates as $event_date ) {
-			// Get the parent event.
-			$event = get_post( $event_date->post_parent );
-			if ( ! $event ) {
-				continue;
-			}
-
-			// Get the event date.
-			$start_date         = get_post_meta( $event_date->ID, 'se_event_date_start', true );
-			$end_date           = get_post_meta( $event_date->ID, 'se_event_date_end', true );
-			$all_day            = get_post_meta( $event_date->ID, 'se_event_all_day', true );
-			$hide_from_calendar = get_post_meta( $event_date->ID, 'se_event_hide_from_calendar', true );
-			$hide_from_feed     = get_post_meta( $event_date->ID, 'se_event_hide_from_feed', true );
-
-			// Add the event date to the compiled events.
-			$compiled_events[] = array(
-				'event_id'                 => absint( $event->ID ),
-				'event_date_id'            => absint( $event_date->ID ),
-				'event_start_date'         => esc_attr( $start_date ),
-				'event_end_date'           => esc_attr( $end_date ),
-				'event_all_day'            => boolval( $all_day ),
-				'event_hide_from_calendar' => boolval( $hide_from_calendar ),
-				'event_hide_from_feed'     => boolval( $hide_from_feed ),
-			);
-		}
-
-		// Return the compiled events.
-		return $compiled_events;
+		_deprecated_function( __METHOD__, '2.2.0', 'SE_Event_Query_Utils::map_events_dates_to_event_dates()' );
+		return SE_Event_Query_Utils::map_events_dates_to_event_dates( $events_dates );
 	}
 
 	/**

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -157,7 +157,7 @@ class SE_Event_Query_Utils {
 		}
 
 		// Return the compiled events.
-		return $compiled_events;
+		return array_values( $compiled_events );
 	}
 
 	/**

--- a/src/classes/class-se-event-query-utils.php
+++ b/src/classes/class-se-event-query-utils.php
@@ -72,6 +72,95 @@ class SE_Event_Query_Utils {
 	}
 
 	/**
+	 * Get published event dates (under a published parent) whose start is in a range.
+	 *
+	 * @param integer $start_timestamp Range start (inclusive) as a Unix timestamp.
+	 * @param integer $end_timestamp   Range end (inclusive) as a Unix timestamp.
+	 *
+	 * @return array
+	 */
+	public static function get_event_dates_for_range( $start_timestamp, $end_timestamp ): array {
+		$args = array(
+			'post_type'      => SE_Event_Post_Type::$event_date_post_type,
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+			'no_found_rows'  => true,
+			'meta_query'     => array(
+				'start_clause' => array(
+					'key'     => 'se_event_date_start',
+					'value'   => array( $start_timestamp, $end_timestamp ),
+					'compare' => 'BETWEEN',
+					'type'    => 'NUMERIC',
+				),
+			),
+			'orderby'        => array( 'start_clause' => 'ASC' ),
+		);
+
+		// Only return dates whose parent event is published (reuse the shared filter).
+		add_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10, 2 );
+		try {
+			$query = new \WP_Query( $args );
+		} finally {
+			remove_filter( 'posts_where', array( __CLASS__, 'filter_event_dates_where' ), 10 );
+		}
+
+		if ( empty( $query->posts ) ) {
+			return array();
+		}
+
+		// Prime parent post + meta caches so per-event enrichment stays cache-only.
+		$parent_ids = array_filter( wp_list_pluck( $query->posts, 'post_parent' ) );
+		if ( ! empty( $parent_ids ) ) {
+			_prime_post_caches( $parent_ids, false, true );
+		}
+
+		return self::map_events_dates_to_event_dates( $query->posts );
+	}
+
+	/**
+	 * Map event date posts to the shared event-date array shape.
+	 *
+	 * @param array $events_dates The event date posts.
+	 *
+	 * @return array{event_id: int, event_date_id: int, event_start_date: string, event_end_date: string, event_all_day: bool, event_hide_from_calendar: bool, event_hide_from_feed: bool}
+	 */
+	public static function map_events_dates_to_event_dates( $events_dates ): array {
+		$compiled_events = array();
+		foreach ( $events_dates as $event_date ) {
+			// Front end only ever surfaces a published date under a published parent.
+			if ( 'publish' !== get_post_status( $event_date ) ) {
+				continue;
+			}
+
+			$event = get_post( $event_date->post_parent );
+			if ( ! $event || 'publish' !== get_post_status( $event ) ) {
+				continue;
+			}
+
+			// Get the event date.
+			$start_date         = get_post_meta( $event_date->ID, 'se_event_date_start', true );
+			$end_date           = get_post_meta( $event_date->ID, 'se_event_date_end', true );
+			$all_day            = get_post_meta( $event_date->ID, 'se_event_all_day', true );
+			$hide_from_calendar = get_post_meta( $event_date->ID, 'se_event_hide_from_calendar', true );
+			$hide_from_feed     = get_post_meta( $event_date->ID, 'se_event_hide_from_feed', true );
+
+			// Add the event date to the compiled events.
+			$compiled_events[] = array(
+				'event_id'                 => absint( $event->ID ),
+				'event_date_id'            => absint( $event_date->ID ),
+				'event_start_date'         => esc_attr( $start_date ),
+				'event_end_date'           => esc_attr( $end_date ),
+				'event_all_day'            => boolval( $all_day ),
+				'event_hide_from_calendar' => boolval( $hide_from_calendar ),
+				'event_hide_from_feed'     => boolval( $hide_from_feed ),
+			);
+		}
+
+		// Return the compiled events.
+		return $compiled_events;
+	}
+
+	/**
 	 * Filter event date queries to ensure parent events are published,
 	 * and optionally include only the correct event date for each parent.
 	 *

--- a/tests/phpunit/Calendar/CalendarHideFromCalendarTest.php
+++ b/tests/phpunit/Calendar/CalendarHideFromCalendarTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Characterisation tests for the calendar grid.
+ *
+ * Locks current behaviour of SE_Calendar::get_month_days(); in particular that
+ * `hide_from_calendar` keeps an event off the calendar grid. No production code
+ * is changed.
+ *
+ * @package Simple_Events
+ */
+class CalendarHideFromCalendarTest extends WP_UnitTestCase {
+
+	/**
+	 * Create a published event with one child date.
+	 *
+	 * @param array $date_args Args for se_event_create_event_date().
+	 * @return array{event_id:int, date_id:int}
+	 */
+	private function make_event_with_date( array $date_args ): array {
+		$event_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'se-event',
+				'post_status' => 'publish',
+			)
+		);
+
+		$date = se_event_create_event_date( $event_id, $date_args );
+		$this->assertNotNull( $date, 'Failed to create the event date fixture.' );
+
+		return array(
+			'event_id' => $event_id,
+			'date_id'  => (int) $date->ID,
+		);
+	}
+
+	/**
+	 * Timestamp for a wall-clock time in the site timezone.
+	 *
+	 * @param string $datetime e.g. '2026-06-15 12:00:00'.
+	 * @return int
+	 */
+	private function ts( string $datetime ): int {
+		return ( new DateTime( $datetime, wp_timezone() ) )->getTimestamp();
+	}
+
+	/**
+	 * Grid days (Y-m-d) a given event-date id renders on.
+	 *
+	 * @param string $month   First of the month, e.g. '2026-06-01'.
+	 * @param int    $date_id The se-event-date post id.
+	 * @return string[]
+	 */
+	private function days_for_date( string $month, int $date_id ): array {
+		$data = SE_Calendar::get_instance()->get_month_days( $month );
+		$days = array();
+		foreach ( $data['days'] as $day ) {
+			foreach ( $day['events'] as $event ) {
+				if ( (int) $event->event_date_id === $date_id ) {
+					$days[] = $day['date_formatted'];
+				}
+			}
+		}
+		return $days;
+	}
+
+	/**
+	 * A normal published, timed event shows on its start day.
+	 */
+	public function test_published_timed_event_shows_on_its_day() {
+		$fixture = $this->make_event_with_date(
+			array(
+				'start_date' => $this->ts( '2026-06-15 12:00:00' ),
+				'end_date'   => $this->ts( '2026-06-15 13:00:00' ),
+				'all_day'    => false,
+			)
+		);
+
+		$this->assertSame(
+			array( '2026-06-15' ),
+			$this->days_for_date( '2026-06-01', $fixture['date_id'] ),
+			'A timed event should render on exactly its start day.'
+		);
+	}
+
+	/**
+	 * Headline: hide_from_calendar keeps the event off the grid entirely.
+	 */
+	public function test_hide_from_calendar_removes_event_from_grid() {
+		$fixture = $this->make_event_with_date(
+			array(
+				'start_date'         => $this->ts( '2026-06-15 12:00:00' ),
+				'end_date'           => $this->ts( '2026-06-15 13:00:00' ),
+				'all_day'            => false,
+				'hide_from_calendar' => true,
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			$this->days_for_date( '2026-06-01', $fixture['date_id'] ),
+			'hide_from_calendar should keep the event off every calendar day.'
+		);
+	}
+
+	/**
+	 * Current placement rule: a timed event crossing midnight shows on no day.
+	 */
+	public function test_timed_event_crossing_midnight_shows_on_no_day() {
+		$fixture = $this->make_event_with_date(
+			array(
+				'start_date' => $this->ts( '2026-06-15 23:00:00' ),
+				'end_date'   => $this->ts( '2026-06-16 01:00:00' ),
+				'all_day'    => false,
+			)
+		);
+
+		$this->assertSame(
+			array(),
+			$this->days_for_date( '2026-06-01', $fixture['date_id'] ),
+			'A timed event whose end runs past its start day shows on no day (current behaviour).'
+		);
+	}
+
+	/**
+	 * An all-day event shows on its start day.
+	 */
+	public function test_all_day_event_shows_on_start_day() {
+		$fixture = $this->make_event_with_date(
+			array(
+				'start_date' => $this->ts( '2026-06-20 00:00:00' ),
+				'end_date'   => $this->ts( '2026-06-20 23:59:59' ),
+				'all_day'    => true,
+			)
+		);
+
+		$this->assertSame(
+			array( '2026-06-20' ),
+			$this->days_for_date( '2026-06-01', $fixture['date_id'] ),
+			'An all-day event should render on its start day.'
+		);
+	}
+}

--- a/tests/phpunit/Calendar/CalendarHideFromCalendarTest.php
+++ b/tests/phpunit/Calendar/CalendarHideFromCalendarTest.php
@@ -14,7 +14,8 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 	 * Create a published event with one child date.
 	 *
 	 * @param array $date_args Args for se_event_create_event_date().
-	 * @return array{event_id:int, date_id:int}
+	 *
+	 * @return array{event_id: int, date_id: int}
 	 */
 	private function make_event_with_date( array $date_args ): array {
 		$event_id = $this->factory->post->create(
@@ -36,8 +37,9 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 	/**
 	 * Timestamp for a wall-clock time in the site timezone.
 	 *
-	 * @param string $datetime e.g. '2026-06-15 12:00:00'.
-	 * @return int
+	 * @param string $datetime Wall-clock time, e.g. '2026-06-15 12:00:00'.
+	 *
+	 * @return integer
 	 */
 	private function ts( string $datetime ): int {
 		return ( new DateTime( $datetime, wp_timezone() ) )->getTimestamp();
@@ -46,8 +48,9 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 	/**
 	 * Grid days (Y-m-d) a given event-date id renders on.
 	 *
-	 * @param string $month   First of the month, e.g. '2026-06-01'.
-	 * @param int    $date_id The se-event-date post id.
+	 * @param string  $month   First of the month, e.g. '2026-06-01'.
+	 * @param integer $date_id The se-event-date post id.
+	 *
 	 * @return string[]
 	 */
 	private function days_for_date( string $month, int $date_id ): array {
@@ -65,6 +68,8 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 
 	/**
 	 * A normal published, timed event shows on its start day.
+	 *
+	 * @return void
 	 */
 	public function test_published_timed_event_shows_on_its_day() {
 		$fixture = $this->make_event_with_date(
@@ -84,6 +89,8 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 
 	/**
 	 * Headline: hide_from_calendar keeps the event off the grid entirely.
+	 *
+	 * @return void
 	 */
 	public function test_hide_from_calendar_removes_event_from_grid() {
 		$fixture = $this->make_event_with_date(
@@ -104,6 +111,8 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 
 	/**
 	 * Current placement rule: a timed event crossing midnight shows on no day.
+	 *
+	 * @return void
 	 */
 	public function test_timed_event_crossing_midnight_shows_on_no_day() {
 		$fixture = $this->make_event_with_date(
@@ -123,6 +132,8 @@ class CalendarHideFromCalendarTest extends WP_UnitTestCase {
 
 	/**
 	 * An all-day event shows on its start day.
+	 *
+	 * @return void
 	 */
 	public function test_all_day_event_shows_on_start_day() {
 		$fixture = $this->make_event_with_date(

--- a/tests/phpunit/EventDates/EventDatesParentStatusTest.php
+++ b/tests/phpunit/EventDates/EventDatesParentStatusTest.php
@@ -66,7 +66,10 @@ class EventDatesParentStatusTest extends WP_UnitTestCase {
 	 * @return int[]
 	 */
 	private function event_ids_for_day() {
-		$dates = SE_Event_Dates::get_event_dates_for_date( $this->day );
+		$tz    = wp_timezone();
+		$start = DateTime::createFromFormat( 'Y-m-d H:i:s', $this->day . ' 00:00:00', $tz )->getTimestamp();
+		$end   = DateTime::createFromFormat( 'Y-m-d H:i:s', $this->day . ' 23:59:59', $tz )->getTimestamp();
+		$dates = SE_Event_Query_Utils::get_event_dates_for_range( $start, $end );
 		return wp_list_pluck( $dates, 'event_id' );
 	}
 


### PR DESCRIPTION
…er them.

#### Changes proposed in this Pull Request

This pull request refactors and modernizes how event dates are fetched and displayed in the calendar grid, improving performance, reliability, and maintainability. The main improvements include eliminating inefficient N+1 queries, centralizing event date logic, and ensuring only published and visible events are shown. Additionally, deprecated methods are updated, and new tests are added to lock in correct behavior.

**Performance and Query Improvements**
- Replaces per-day (N+1) event date queries in `SE_Calendar::get_month_days` with a single range query, bucketing results per day for efficient access. This significantly improves calendar grid performance. [[1]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR146-R158) [[2]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfL379-R421) [[3]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR470-R500) [[4]](diffhunk://#diff-1080ceab271979b6e31f78e12d7b9a738362b450b0c990dbf01f9d23ced89124R74-R162)
- Ensures all event date queries (including next/previous month navigation) only consider published event dates under published parent events, matching the grid's logic. [[1]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR264) [[2]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR290-R296) [[3]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR342) [[4]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR371-R373) [[5]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR385-R387) [[6]](diffhunk://#diff-1080ceab271979b6e31f78e12d7b9a738362b450b0c990dbf01f9d23ced89124R74-R162)

**Codebase Modernization and Cleanup**
- Introduces `SE_Event_Query_Utils::get_event_dates_for_range` as the centralized way to fetch event dates, and deprecates legacy methods in `SE_Event_Dates` in favor of this new utility. [[1]](diffhunk://#diff-aca47829e930e75e2a4c0f3a2448c6976b48995b938f89dc77e6f97de7521d34L263-R281) [[2]](diffhunk://#diff-aca47829e930e75e2a4c0f3a2448c6976b48995b938f89dc77e6f97de7521d34R291-R331) [[3]](diffhunk://#diff-1080ceab271979b6e31f78e12d7b9a738362b450b0c990dbf01f9d23ced89124R74-R162)
- Refactors `get_events_by_date` to use pre-bucketed event dates and enforces `hide_from_calendar` logic at the display level.

**Testing and Permissions**
- Adds comprehensive tests to verify that hidden events are not shown and that day placement rules are correct, locking in current behavior.
- Updates `.claude/settings.json` to allow test access to the new code.

**Summary of Most Important Changes**

**Performance and Query Logic**
* Calendar grid now fetches all visible events for the month in a single query and buckets them per day, eliminating N+1 query inefficiency. [[1]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR146-R158) [[2]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR470-R500)
* All event date queries (including navigation) are filtered to only include published dates under published parent events, ensuring consistency and correctness. [[1]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR264) [[2]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR290-R296) [[3]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR342) [[4]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR371-R373) [[5]](diffhunk://#diff-e7b65d56e506f84ad2c6f9999c4e58423c2672eae08c35dab4477f9bdcd171cfR385-R387) [[6]](diffhunk://#diff-1080ceab271979b6e31f78e12d7b9a738362b450b0c990dbf01f9d23ced89124R74-R162)

**Code Modernization**
* Introduces `SE_Event_Query_Utils::get_event_dates_for_range` and `map_events_dates_to_event_dates` as the new standard for event date queries; deprecates and redirects legacy methods in `SE_Event_Dates`. [[1]](diffhunk://#diff-aca47829e930e75e2a4c0f3a2448c6976b48995b938f89dc77e6f97de7521d34L263-R281) [[2]](diffhunk://#diff-aca47829e930e75e2a4c0f3a2448c6976b48995b938f89dc77e6f97de7521d34R291-R331) [[3]](diffhunk://#diff-1080ceab271979b6e31f78e12d7b9a738362b450b0c990dbf01f9d23ced89124R74-R162)

**Testing**
* Adds PHPUnit tests in `CalendarHideFromCalendarTest.php` to verify correct grid behavior for hidden events, all-day events, and timed events crossing midnight.

**Permissions**
* Updates `.claude/settings.json` to allow test harnesses to access the new event query code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved month calendar placement for timed and all-day events, including events that cross midnight.
  * Ensured events marked as hidden from the calendar never render on calendar grid days.
  * Tightened calendar event results to only include event dates whose parent events are published.
* **Performance**
  * Improved month rendering by fetching event dates for the visible range in a single pass and rendering from pre-grouped results.
* **Tests**
  * Added PHPUnit coverage for timed, all-day, hidden, and cross-midnight rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->