### PR TITLE
Respect hide_from_feed for calendar-only events in feeds and Query Loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ Copy the `team51-focal-point` folder to your `mu-plugins` directory.
 
 ## Changelog
 
+### 2.1.4
+
+- **Event date visibility:** fixed `find_event_dates()` so **Hide from calendar** and **Hide from feed** are applied independently based on the requesting context. Calendar day queries no longer exclude dates marked **Hide from feed**, allowing calendar-only entries (for example all-day closed markers) to appear on the calendar while remaining hidden from feed/list surfaces.
+
 ### 2.1.3
 
 - **Calendar grid alignment:** fixed month grid date placement when WordPress **Week Starts On** is set to Sunday (or any `start_of_week` other than Monday). Dates and events now appear under the correct weekday column.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "wpcomsp-simple-events",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "license": "GPL-2.0-or-later",
             "dependencies": {
                 "ajv": "^8.17.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "wpcomsp-simple-events",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "A simple Gutenberg-first event management plugin that integrates with WooCommerce Box Office.",
     "author": {
         "name": "WordPress.com Special Projects Team",

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Simple Events Plugin bootstrap file.
  *
  * @since       1.0.0
- * @version     2.1.3
+ * @version     2.1.4
  * @author      WordPress.com Special Projects
  * @license     GPL-3.0-or-later
  *
@@ -14,7 +14,7 @@
  * Description:             Event management frontend for WooCommerce Box Office.
  * Requires at least:       6.5
  * Tested up to:            6.9
- * Version:                 2.1.3
+ * Version:                 2.1.4
  * Requires PHP:            8.0
  * Author:                  WordPress.com Special Projects
  * Author URI:              https://wpspecialprojects.wordpress.com

--- a/src/classes/class-se-event-dates.php
+++ b/src/classes/class-se-event-dates.php
@@ -323,11 +323,19 @@ class SE_Event_Dates {
 
 		$mapped = self::map_events_dates_to_event_dates( $query->posts );
 
-		// Remove the event dates that are hidden from the calendar or feed.
+		// Remove event dates hidden from the requested contexts.
 		return array_filter(
 			$mapped,
 			function ( $event_date ) use ( $hide_from_calendar, $hide_from_feed ) {
-				return ! $event_date['event_hide_from_calendar'] && ! $event_date['event_hide_from_feed'];
+				if ( $hide_from_calendar && $event_date['event_hide_from_calendar'] ) {
+					return false;
+				}
+
+				if ( $hide_from_feed && $event_date['event_hide_from_feed'] ) {
+					return false;
+				}
+
+				return true;
 			}
 		);
 	}


### PR DESCRIPTION
#### Issue

Per-date **Hide from feed** was also removing the date from the calendar, even when **Hide from calendar** was off. `find_event_dates()` ignored its context flags and always excluded both feed-hidden and calendar-hidden dates.

#### Changes proposed in this Pull Request

- Respect `$hide_from_calendar` and `$hide_from_feed` in `find_event_dates()` so each flag is applied only when its context parameter is true.
- Calendar queries (`get_event_dates_for_date( $date, true, false )`) exclude calendar-hidden dates only.
- Feed queries (`get_event_dates_for_date( $date, false, true )`) exclude feed-hidden dates only.

#### Testing instructions

1. Create or edit an event date with **Hide from feed** on and **Hide from calendar** off.
2. Confirm the date appears on the calendar for that day.
3. Confirm the same date is excluded from feed-context results (e.g. upcoming list / feed query).
4. Toggle **Hide from calendar** on (feed off) and confirm the date disappears from the calendar but remains in feed-context results.
5. Confirm a date with neither toggle set still appears in both contexts.

Mentions #
@gin0115 @tommusrhodus 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Hide from calendar" and "Hide from feed" settings to work independently. Calendar-only entries (such as all-day closure markers) now display on calendars while remaining hidden from feeds and lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->